### PR TITLE
CI: Fix `gh api` status update commands

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -669,12 +669,14 @@ jobs:
         if: github.event.action == 'zallet-interop-request'
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          SHARD: ${{ matrix.shard }}
+        shell: sh
         run: >
           gh api "repos/zcash/wallet/statuses/${{ github.event.client_payload.sha }}"
           --field state=pending
           --field target_url="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           --field description="In progress"
-          --field context="Integration tests / RPC tests tier ${{ matrix.tier }} platform ${{ matrix.platform }} ${{ matrix.shard }}"
+          --field context="Integration tests / RPC tests tier ${{ matrix.tier }} platform ${{ matrix.platform }} ${SHARD}"
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -777,9 +779,11 @@ jobs:
         if: always() && github.event.action == 'zallet-interop-request'
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          SHARD: ${{ matrix.shard }}
+        shell: sh
         run: >
           gh api "repos/zcash/wallet/statuses/${{ github.event.client_payload.sha }}"
           --field state="${{ case(job.status == 'cancelled', 'error', job.status) }}"
           --field target_url="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           --field description="Finished"
-          --field context="Integration tests / RPC tests tier ${{ matrix.tier }} platform ${{ matrix.platform }} ${{ matrix.shard }}"
+          --field context="Integration tests / RPC tests tier ${{ matrix.tier }} platform ${{ matrix.platform }} ${SHARD}"


### PR DESCRIPTION
- `-f` doesn't exist as a short form of `--field`
- The newline at the end of a YAML `run: >` block is incorrectly interpreted by `gh api` as part of the last `--field`, so we inline the entire command instead.

Part of COR-980.