### PR TITLE
CI: Enable interop requests from ZcashFoundation/zebra

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,9 @@ on:
       - '**.md'
       - 'COPYING'
   repository_dispatch:
-    types: [zallet-interop-request]
+    types:
+      - zebra-interop-request
+      - zallet-interop-request
 
 permissions:
   contents: read
@@ -316,7 +318,14 @@ jobs:
           requesting-repository: ${{ steps.repo-ids.outputs.requesting-repository }}
           job-name: "Build zebrad on ${{ matrix.platform }}${{ matrix.required_suffix }}"
 
+      - name: Use specified ZcashFoundation/zebra commit
+        if: github.event.action == 'zebra-interop-request'
+        shell: sh
+        env:
+          SHA: ${{ github.event.client_payload.sha }}
+        run: echo "ZEBRA_REF=${SHA}" >> $GITHUB_ENV
       - name: Use ZcashFoundation/zebra current main
+        if: github.event.action != 'zebra-interop-request'
         run: echo "ZEBRA_REF=refs/heads/main" >> $GITHUB_ENV
 
       - name: Check out ZcashFoundation/zebra
@@ -522,7 +531,10 @@ jobs:
 
       - name: Use specified zcash/wallet commit
         if: github.event.action == 'zallet-interop-request'
-        run: echo "ZALLET_REF=${{ github.event.client_payload.sha }}" >> $GITHUB_ENV
+        shell: sh
+        env:
+          SHA: ${{ github.event.client_payload.sha }}
+        run: echo "ZALLET_REF=${SHA}" >> $GITHUB_ENV
       - name: Use zcash/wallet current main
         if: github.event.action != 'zallet-interop-request'
         run: echo "ZALLET_REF=refs/heads/main" >> $GITHUB_ENV


### PR DESCRIPTION
This would need to be paired with a CI trigger in their repo equivalent to https://github.com/zcash/wallet/blob/a96b778a4dab0421cc93006a31d7d724a58ff0fe/.github/workflows/ci.yml#L118-L136 (but using the `zebra-interop-request` event instead), along with the necessary GitHub App to power the integration (cc @nuttycom who set the Zallet one up).