### PR TITLE
add correct args to start zainod

### DIFF
--- a/qa/rpc-tests/test_framework/util.py
+++ b/qa/rpc-tests/test_framework/util.py
@@ -1116,7 +1116,7 @@ def start_zaino(i, dirname, extra_args=None, rpchost=None, timewait=None, binary
     if binary is None:
         binary = zaino_binary()
     config = update_zainod_conf(datadir, rpc_port(i), indexer_rpc_port(i), zaino_rpc_port(i), zaino_grpc_port(i), extra_args)
-    args = [ binary, "-c="+config ]
+    args = [ binary, "start", "-c="+config ]
 
     zainod_processes[i] = subprocess.Popen(args, stderr=stderr)
     if os.getenv("PYTHON_DEBUG", ""):


### PR DESCRIPTION
Addresses:  https://github.com/zingolabs/integration-tests/issues/1

zainod (currently) requires "start" before the config flag.  This may not be the correct fix, but it does allow the test to run to completion without other errors.