### PR TITLE
Address post-merge review comments from daira

### DIFF
--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -466,8 +466,8 @@ class RPCTestHandler:
                     log_out.seek(0), log_err.seek(0)
                     [stdout, stderr] = [l.read().decode('utf-8') for l in (log_out, log_err)]
                     log_out.close(), log_err.close()
-                    # Zebra uses stderr for welcome messages, panics, etc., so we
-                    # cannot use stderr emptiness as a success indicator.
+                    # Zebra uses stderr for welcome messages and other non-error
+                    # output, so we cannot use stderr emptiness as a success indicator.
                     # See https://github.com/ZcashFoundation/zebra/issues/10316
                     passed = proc.returncode == 0
                     self.num_running -= 1

--- a/qa/rpc-tests/feature_backup_non_finalized_state.py
+++ b/qa/rpc-tests/feature_backup_non_finalized_state.py
@@ -36,7 +36,7 @@ class BackupNonFinalized(BitcoinTestFramework):
         blocks = self.nodes[0].getblockchaininfo()['blocks']
         assert_equal(blocks, 10)
 
-        # Generate more blocks and make sure the blockchain is not stall
+        # Generate more blocks and make sure the blockchain is not stalled
         self.nodes[0].generate(1)
         blocks = self.nodes[0].getblockchaininfo()['blocks']
         assert_equal(blocks, 11)

--- a/qa/rpc-tests/feature_nu6.py
+++ b/qa/rpc-tests/feature_nu6.py
@@ -82,7 +82,6 @@ class PoolsTest(BitcoinTestFramework):
 
         getblockchaininfo = self.nodes[0].getblockchaininfo()
         value_pools_from_getblockchaininfo = getblockchaininfo['valuePools']
-        (transparent_pool, sapling_pool, sprout_pool, orchard_pool, deferred_pool) = get_value_pools(value_pools_from_getblockchaininfo)
 
         assert_value_pools_equals(value_pools_from_getblock, value_pools_from_getblockchaininfo)
 
@@ -113,7 +112,6 @@ class PoolsTest(BitcoinTestFramework):
 
         getblockchaininfo = self.nodes[0].getblockchaininfo()
         value_pools_from_getblockchaininfo = getblockchaininfo['valuePools']
-        (transparent_pool, sapling_pool, sprout_pool, orchard_pool, deferred_pool) = get_value_pools(value_pools_from_getblockchaininfo)
 
         assert_value_pools_equals(value_pools_from_getblock, value_pools_from_getblockchaininfo)
 
@@ -143,7 +141,6 @@ class PoolsTest(BitcoinTestFramework):
 
         getblockchaininfo = self.nodes[0].getblockchaininfo()
         value_pools_from_getblockchaininfo = getblockchaininfo['valuePools']
-        (transparent_pool, sapling_pool, sprout_pool, orchard_pool, deferred_pool) = get_value_pools(value_pools_from_getblockchaininfo)
 
         assert_value_pools_equals(value_pools_from_getblock, value_pools_from_getblockchaininfo)
 
@@ -222,7 +219,6 @@ class PoolsTest(BitcoinTestFramework):
 
         getblockchaininfo = self.nodes[0].getblockchaininfo()
         value_pools_from_getblockchaininfo = getblockchaininfo['valuePools']
-        (transparent_pool, sapling_pool, sprout_pool, orchard_pool, deferred_pool) = get_value_pools(value_pools_from_getblockchaininfo)
 
         assert_value_pools_equals(value_pools_from_getblock, value_pools_from_getblockchaininfo)
 
@@ -241,7 +237,6 @@ class PoolsTest(BitcoinTestFramework):
 
         getblockchaininfo = self.nodes[0].getblockchaininfo()
         value_pools_from_getblockchaininfo = getblockchaininfo['valuePools']
-        (transparent_pool, sapling_pool, sprout_pool, orchard_pool, deferred_pool) = get_value_pools(value_pools_from_getblockchaininfo)
 
         assert_value_pools_equals(value_pools_from_getblock, value_pools_from_getblockchaininfo)
 


### PR DESCRIPTION
@daira left review comments on the squashed commit [`f8d7328`](https://github.com/zcash/integration-tests/commit/f8d73285993fa929e2639ba3225f68b49ca8b6a8) that introduced the Z3 integration test framework. 
Since those comments were made on a commit (not a PR), they risk being overlooked, so this PR captures and addresses them.
   
**Changes:**
   
- `qa/pull-tester/rpc-tests.py`: Improve comment accuracy — Zebra's stderr output is due to welcome messages and other non-error output, not panics. ([comment](https://github.com/zcash/integration-tests/commit/f8d73285993fa929e2639ba3225f68b49ca8b6a8#r178561181))
   
- `qa/rpc-tests/feature_backup_non_finalized_state.py`: Fix typo: "not stall" → "not stalled". ([comment](https://github.com/zcash/integration-tests/commit/f8d73285993fa929e2639ba3225f68b49ca8b6a8#r178561377))
   
- `qa/rpc-tests/feature_nu6.py`: Remove 5 unnecessary pool destructuring lines where variables were assigned from `getblockchaininfo` but never used before being overwritten. ([comment 1](https://github.com/zcash/integration-tests/commit/f8d73285993fa929e2639ba3225f68b49ca8b6a8#r178561598), [2](https://github.com/zcash/integration-tests/commit/f8d73285993fa929e2639ba3225f68b49ca8b6a8#r178561633),  [3](https://github.com/zcash/integration-tests/commit/f8d73285993fa929e2639ba3225f68b49ca8b6a8#r178561663), [4](https://github.com/zcash/integration-tests/commit/f8d73285993fa929e2639ba3225f68b49ca8b6a8#r178561747),  [5](https://github.com/zcash/integration-tests/commit/f8d73285993fa929e2639ba3225f68b49ca8b6a8#r178561777))
