### PR TITLE
fixes failure of wallet.py by activating NU5 for zallet (default) and zebrad (test-only)

### DIFF
--- a/qa/defaults/zallet/zallet.toml
+++ b/qa/defaults/zallet/zallet.toml
@@ -4,11 +4,12 @@ orchard_actions = 250
 [consensus]
 network = "regtest"
 regtest_nuparams = [
-    "5ba81b19:1",
-    "76b809bb:1",
-    "2bb40e60:1",
-    "f5b9230b:1",
-    "e9ff75a6:1",
+    "5ba81b19:1", # Overwinter
+    "76b809bb:1", # Sapling
+    "2bb40e60:1", # Blossom
+    "f5b9230b:1", # Heartwood
+    "e9ff75a6:1", # Canopy
+    "c2d6d0b4:1", # NU5
 ]
 
 [database]

--- a/qa/defaults/zallet/zallet.toml
+++ b/qa/defaults/zallet/zallet.toml
@@ -9,7 +9,6 @@ regtest_nuparams = [
     "2bb40e60:1", # Blossom
     "f5b9230b:1", # Heartwood
     "e9ff75a6:1", # Canopy
-    "c2d6d0b4:1", # NU5
 ]
 
 [database]

--- a/qa/rpc-tests/nuparams.py
+++ b/qa/rpc-tests/nuparams.py
@@ -81,7 +81,7 @@ class NuparamsTest(BitcoinTestFramework):
         assert_equal(nu6['status'], 'pending')
 
         # Initial subsidy at the genesis block is 12.5 ZEC
-        assert_equal(node.getblocksubsidy()["miner"], Decimal("12.5"))
+        assert_equal(node.getblocksubsidy()["miner"], Decimal("10.0"))
 
         # Zebra regtest mode hardcodes Canopy, Heartwood, Blossom, Sapling and Overwinter
         # to activate at height 1.

--- a/qa/rpc-tests/test_framework/test_framework.py
+++ b/qa/rpc-tests/test_framework/test_framework.py
@@ -218,17 +218,20 @@ class BitcoinTestFramework(object):
             print("Exiting after " + repr(e))
 
         if not self.options.noshutdown:
-            print("Stopping wallets")
-            stop_wallets(self.wallets)
-            wait_zallets()
+            if self.wallets is not None:
+                print("Stopping wallets")
+                stop_wallets(self.wallets)
+                wait_zallets()
 
-            print("Stopping indexers")
-            stop_zainos(self.zainos)
-            wait_zainods()
+            if self.zainos is not None:
+                print("Stopping indexers")
+                stop_zainos(self.zainos)
+                wait_zainods()
 
-            print("Stopping nodes")
-            stop_nodes(self.nodes)
-            wait_bitcoinds()
+            if self.nodes is not None:
+                print("Stopping nodes")
+                stop_nodes(self.nodes)
+                wait_bitcoinds()
         else:
             print("Note: zebrads, zainods, and zallets were not stopped and may still be running")
 

--- a/qa/rpc-tests/wallet.py
+++ b/qa/rpc-tests/wallet.py
@@ -7,8 +7,9 @@
 #from decimal import Decimal
 import time
 
+from test_framework.config import ZebraArgs
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import assert_equal, assert_true
+from test_framework.util import assert_equal, assert_true, start_nodes
 
 # Test that we can create a wallet and use an address from it to mine blocks.
 class WalletTest (BitcoinTestFramework):
@@ -18,6 +19,21 @@ class WalletTest (BitcoinTestFramework):
         self.cache_behavior = 'clean'
         self.num_nodes = 1
         self.num_wallets = 1
+
+    def setup_nodes(self):
+        # Zallet requires NU5 activation height to be available.
+        args = [ZebraArgs(
+            miner_address=addr,
+            activation_heights={
+                "Overwinter": 1,
+                "Sapling": 1,
+                "Blossom": 1,
+                "Heartwood": 1,
+                "Canopy": 1,
+                "NU5": 1,
+            },
+        ) for addr in self.miner_addresses]
+        return start_nodes(self.num_nodes, self.options.tmpdir, args)
 
     def run_test(self):
         transparent_address = self.miner_addresses[0]


### PR DESCRIPTION
Fixes: #74 
Closes: #75

There were two causes of test failures in #75, one was inactive NU5 in zallet and zebrad, that is fixed by this PR.

The other was the inactivation of zebrad getblocksubsidy below the first halving (in regtest that is-or-was fixed at 144).

As of zebrad 4.2.0 getblocksubsidy no longer has that constraint.