### PR TITLE
allow wallet.py to pass by activating NU5 in zebrad and matching in zallet

### DIFF
--- a/qa/rpc-tests/test_framework/test_framework.py
+++ b/qa/rpc-tests/test_framework/test_framework.py
@@ -15,11 +15,15 @@ import tempfile
 import time
 import traceback
 
+import toml
+
 from .config import ZebraArgs
 from .proxy import JSONRPCException
 from .util import (
+    NU5_BRANCH_ID,
     zcashd_binary,
     initialize_chain,
+    nustr,
     prepare_wallets_for_mining,
     start_nodes,
     start_wallets,
@@ -33,6 +37,8 @@ from .util import (
     wait_bitcoinds,
     wait_zainods,
     wait_zallets,
+    wallet_dir,
+    zallet_config,
     enable_coverage,
     check_json_precision,
     PortSeed,
@@ -242,6 +248,36 @@ class BitcoinTestFramework(object):
         else:
             print("Failed")
             sys.exit(1)
+
+
+class NU5ActiveTestFramework(BitcoinTestFramework):
+    """BitcoinTestFramework subclass that activates NU5 for Zallet tests."""
+
+    def setup_nodes(self):
+        if self.miner_addresses is None:
+            args = [ZebraArgs(activation_heights={"NU5": 1})] * self.num_nodes
+        else:
+            args = [
+                ZebraArgs(miner_address=addr, activation_heights={"NU5": 1})
+                for addr in self.miner_addresses
+            ]
+        return start_nodes(self.num_nodes, self.options.tmpdir, args)
+
+    def _add_nu5_to_wallet_configs(self):
+        nu5_param = "%s:1" % nustr(NU5_BRANCH_ID)
+        for i in range(self.num_wallets):
+            config_path = zallet_config(wallet_dir(self.options.tmpdir, i))
+            with open(config_path, "r", encoding="utf8") as f:
+                config = toml.load(f)
+            params = config['consensus']['regtest_nuparams']
+            if nu5_param not in params:
+                params.append(nu5_param)
+            with open(config_path, "w", encoding="utf8") as f:
+                toml.dump(config, f)
+
+    def prepare_wallets(self):
+        self._add_nu5_to_wallet_configs()
+        super().prepare_wallets()
 
 
 # Test framework for doing p2p comparison testing, which sets up some bitcoind

--- a/qa/rpc-tests/wallet.py
+++ b/qa/rpc-tests/wallet.py
@@ -7,11 +7,15 @@
 #from decimal import Decimal
 import time
 
-from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import assert_equal, assert_true
+from test_framework.test_framework import NU5ActiveTestFramework
+from test_framework.util import (
+    assert_equal,
+    assert_true,
+)
+
 
 # Test that we can create a wallet and use an address from it to mine blocks.
-class WalletTest (BitcoinTestFramework):
+class WalletTest (NU5ActiveTestFramework):
 
     def __init__(self):
         super().__init__()


### PR DESCRIPTION
Fixes:  #74

To minimize divergence from the historical test state NU5 activation needs to be activated only in those tests that require it.

This change adds a sub-class NU5ActiveTestFramework that inherits from BitcoinTestFramework that:

 1.  sets all zebrads activation args to include NU5 at height 1
 2.  updates the prepare_wallet method in the subclass to match zallet config to activate NU5:1

This class is uniquely subclassed by WalletTest.