### PR TITLE
Chore/z shieldcoinbase tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ src/*
 
 poetry.lock
 .venv
+venv/*

--- a/qa/defaults/zallet/zallet.toml
+++ b/qa/defaults/zallet/zallet.toml
@@ -9,6 +9,7 @@ regtest_nuparams = [
     "2bb40e60:1",
     "f5b9230b:1",
     "e9ff75a6:1",
+    "c2d6d0b4:1",
 ]
 
 [database]

--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -160,6 +160,7 @@ NEW_SCRIPTS= [
     # vv Tests less than 2m vv
     # vv Tests less than 60s vv
     'addnode.py',
+    'wallet_z_shieldcoinbase.py',
     # vv Tests less than 30s vv
     'feature_nu6.py',
     'feature_backup_non_finalized_state.py',

--- a/qa/rpc-tests/wallet_shieldcoinbase.py
+++ b/qa/rpc-tests/wallet_shieldcoinbase.py
@@ -5,8 +5,9 @@
 
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.authproxy import JSONRPCException
+from test_framework.config import ZebraArgs
 from test_framework.util import assert_equal, initialize_chain_clean, \
-    start_node, connect_nodes_bi, sync_blocks, sync_mempools, \
+    start_nodes, connect_nodes_bi, sync_blocks, sync_mempools, \
     wait_and_assert_operationid_status, get_coinbase_address, \
     NU5_BRANCH_ID, nuparams
 from test_framework.zip317 import conventional_fee, ZIP_317_FEE
@@ -14,28 +15,29 @@ from test_framework.zip317 import conventional_fee, ZIP_317_FEE
 from decimal import Decimal
 
 class WalletShieldCoinbaseTest (BitcoinTestFramework):
-    def setup_chain(self):
-        print("Initializing test directory "+self.options.tmpdir)
-        initialize_chain_clean(self.options.tmpdir, 4)
+    def __init__(self):
+        super().__init__()
+        self.num_nodes = 3
+        self.num_wallets = 3
+        self.cache_behavior = 'clean'
 
-    def setup_network(self, split=False):
+    def setup_nodes(self):
         args = [
-            '-regtestprotectcoinbase',
-            '-debug=zrpcunsafe',
-            nuparams(NU5_BRANCH_ID, self.nu5_activation),
-            '-allowdeprecated=z_getnewaddress',
-            '-allowdeprecated=z_getbalance',
-            '-debug=mempool',
+            ZebraArgs(
+                miner_address=addr,
+                activation_heights={"NU5": self.nu5_activation},
+            ) for addr in self.miner_addresses
         ]
-        self.nodes = []
-        self.nodes.append(start_node(0, self.options.tmpdir, args))
-        self.nodes.append(start_node(1, self.options.tmpdir, args))
-        self.nodes.append(start_node(2, self.options.tmpdir, args))
-        connect_nodes_bi(self.nodes,0,1)
-        connect_nodes_bi(self.nodes,1,2)
-        connect_nodes_bi(self.nodes,0,2)
-        self.is_network_split=False
-        self.sync_all()
+        return start_nodes(self.num_nodes, self.options.tmpdir, args)
+
+        #args = [[
+            # '-regtestprotectcoinbase', doesn't exist in zebra
+            # '-debug=zrpcunsafe',
+            # nuparams(NU5_BRANCH_ID, self.nu5_activation),
+            # '-allowdeprecated=z_getnewaddress',
+            # '-allowdeprecated=z_getbalance',
+            # '-debug=mempool',
+        #]]
 
     def run_test (self):
         print("Mining blocks...")
@@ -53,9 +55,12 @@ class WalletShieldCoinbaseTest (BitcoinTestFramework):
         self.sync_all()
         self.nodes[1].generate(101)
         self.sync_all()
+        # these will be "wallets", not "nodes"
+        """
         assert_equal(Decimal(self.nodes[0].getbalance()), Decimal('50'))
         assert_equal(Decimal(self.nodes[1].getbalance()), Decimal('10'))
         assert_equal(Decimal(self.nodes[2].getbalance()), Decimal('30'))
+        """
 
         # create one zaddr that is the target of all shielding
         myzaddr = self.test_init_zaddr(self.nodes[0])

--- a/qa/rpc-tests/wallet_z_shieldcoinbase.py
+++ b/qa/rpc-tests/wallet_z_shieldcoinbase.py
@@ -1,0 +1,245 @@
+#!/usr/bin/env python3
+# Copyright (c) 2025-2026 The Zcash developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or https://www.opensource.org/licenses/mit-license.php .
+
+#
+# Test z_shieldcoinbase RPC against the Z3 stack (zebrad + zaino + zallet).
+#
+# This is a NEW test that exercises Zallet's z_shieldcoinbase implementation
+# directly, rather than attempting to migrate the legacy zcashd tests.
+# It uses 1 node + 1 wallet to avoid the Zaino race condition with
+# concurrent wallets.
+#
+
+import time
+
+from decimal import Decimal
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.authproxy import JSONRPCException
+from test_framework.config import ZebraArgs
+from test_framework.util import (
+    assert_equal,
+    assert_true,
+    start_nodes,
+    wait_and_assert_operationid_status,
+    wait_and_assert_operationid_status_result,
+)
+
+# Coinbase outputs require 100 confirmations before they can be spent.
+COINBASE_MATURITY = 100
+
+
+class WalletZShieldCoinbaseTest(BitcoinTestFramework):
+
+    def __init__(self):
+        super().__init__()
+        self.num_nodes = 1
+        self.num_wallets = 1
+        self.cache_behavior = 'clean'
+
+    def setup_nodes(self):
+        # NU5 must be explicitly activated for both zebrad and zallet.
+        # Zallet's z_shieldcoinbase hardcodes Orchard change strategy which
+        # requires NU5. The default zallet.toml includes NU5 at height 1,
+        # and we must match that on the zebrad side.
+        args = [
+            ZebraArgs(
+                miner_address=addr,
+                activation_heights={"NU5": 1},
+            ) for addr in self.miner_addresses
+        ]
+        return start_nodes(self.num_nodes, self.options.tmpdir, args)
+
+    def run_test(self):
+        node = self.nodes[0]
+        wallet = self.wallets[0]
+
+        # The miner address for account 0 (set up by prepare_wallets_for_mining).
+        miner_taddr = self.miner_addresses[0]
+
+        print("Mining initial blocks to mature coinbase...")
+        # Mine enough blocks so that the earliest coinbase UTXOs have
+        # more than 100 confirmations.
+        node.generate(COINBASE_MATURITY + 20)
+        time.sleep(10)
+
+        # Verify the wallet sees the transparent balance.
+        wallet_balance = wallet.z_gettotalbalance(1, True)
+        assert_true(
+            Decimal(wallet_balance['transparent']) > Decimal('0'),
+            "Wallet should see transparent balance"
+        )
+        print("  Balance verified: {} ZEC transparent".format(wallet_balance['transparent']))
+
+        # Get a shielded address from account 0 (with Orchard receiver).
+        addr_result = wallet.z_getaddressforaccount(0, ["orchard"])
+        zaddr = addr_result['address']
+        print("  Shielded address (Orchard UA): {}...".format(zaddr[:20]))
+
+        # ================================================================
+        # Error handling tests (no coinbase maturity needed)
+        # ================================================================
+
+        print("Test 1: Fee must be null...")
+        try:
+            wallet.z_shieldcoinbase(miner_taddr, zaddr, Decimal('0.001'))
+            raise AssertionError("Should have thrown for non-null fee")
+        except JSONRPCException as e:
+            assert_true(
+                "fee field must be null" in e.error['message'],
+                "Expected fee-must-be-null error, got: " + e.error['message']
+            )
+        print("  PASSED")
+
+        print("Test 2: Invalid toaddress (transparent)...")
+        try:
+            wallet.z_shieldcoinbase(miner_taddr, miner_taddr, None)
+            raise AssertionError("Should have thrown for transparent toaddress")
+        except JSONRPCException as e:
+            assert_true(
+                "toaddress must be a shielded address" in e.error['message'],
+                "Expected shielded-address error, got: " + e.error['message']
+            )
+        print("  PASSED")
+
+        print("Test 3: Invalid fromaddress...")
+        try:
+            wallet.z_shieldcoinbase("not_a_real_address", zaddr, None)
+            raise AssertionError("Should have thrown for invalid fromaddress")
+        except JSONRPCException as e:
+            assert_true(
+                "Invalid from address" in e.error['message'] or
+                "unknown address format" in e.error['message'],
+                "Expected invalid-address error, got: " + e.error['message']
+            )
+        print("  PASSED")
+
+        print("Test 4: Shielded fromaddress rejected...")
+        try:
+            wallet.z_shieldcoinbase(zaddr, zaddr, None)
+            raise AssertionError("Should have thrown for shielded fromaddress")
+        except JSONRPCException as e:
+            assert_true(
+                "only supports transparent source" in e.error['message'] or
+                "should be a taddr" in e.error['message'],
+                "Expected transparent-only error, got: " + e.error['message']
+            )
+        print("  PASSED")
+
+        print("Test 5: LegacyCompat privacy policy rejected...")
+        try:
+            wallet.z_shieldcoinbase(miner_taddr, zaddr, None, None, None, "LegacyCompat")
+            raise AssertionError("Should have thrown for LegacyCompat")
+        except JSONRPCException as e:
+            assert_true(
+                "LegacyCompat" in e.error['message'],
+                "Expected LegacyCompat rejection, got: " + e.error['message']
+            )
+        print("  PASSED")
+
+        print("Test 6: Same-account enforcement...")
+        account2 = wallet.z_getnewaccount("test-account-2")
+        account2_uuid = account2['account_uuid']
+        addr2_result = wallet.z_getaddressforaccount(account2_uuid, ["orchard"])
+        zaddr2 = addr2_result['address']
+        try:
+            wallet.z_shieldcoinbase(miner_taddr, zaddr2, None)
+            raise AssertionError("Should have thrown for cross-account shielding")
+        except JSONRPCException as e:
+            assert_true(
+                "same account" in e.error['message'].lower() or
+                "fromaddress and toaddress must belong to the same account" in e.error['message'],
+                "Expected same-account error, got: " + e.error['message']
+            )
+        print("  PASSED")
+
+        # ================================================================
+        # Shielding transaction tests (require mature coinbase)
+        # ================================================================
+
+        print("Test 7: Basic shielding (explicit taddr -> Orchard UA)...")
+        opid = wallet.z_shieldcoinbase(miner_taddr, zaddr, None)
+        assert_true(isinstance(opid, str), "Expected opid string, got: {}".format(type(opid)))
+        assert_true(opid.startswith("opid-"), "Expected opid to start with 'opid-', got: {}".format(opid))
+
+        txid = wait_and_assert_operationid_status(wallet, opid)
+        assert_true(txid is not None, "Shielding transaction should have succeeded")
+        print("  Shielding tx: {}".format(txid))
+
+        # Mine a block to confirm the shielding transaction.
+        node.generate(1)
+        time.sleep(3)
+
+        # Verify the wallet sees the shielded balance.
+        wallet_balance = wallet.z_gettotalbalance(1, True)
+        shielded = Decimal(wallet_balance['private'])
+        print("  Shielded balance: {} ZEC".format(shielded))
+        assert_true(shielded > Decimal('0'), "Shielded balance should be positive after shielding")
+        print("  PASSED")
+
+        print("Test 8: Wildcard shielding (* -> Orchard UA)...")
+        # Mine blocks to create AND mature new coinbase UTXOs.
+        node.generate(COINBASE_MATURITY + 10)
+        time.sleep(5)
+
+        pre_balance = wallet.z_gettotalbalance(1, True)
+        pre_shielded = Decimal(pre_balance['private'])
+
+        opid = wallet.z_shieldcoinbase("*", zaddr, None)
+        txid = wait_and_assert_operationid_status(wallet, opid)
+        assert_true(txid is not None, "Wildcard shielding should have succeeded")
+        print("  Wildcard shielding tx: {}".format(txid))
+
+        node.generate(1)
+        time.sleep(3)
+
+        post_balance = wallet.z_gettotalbalance(1, True)
+        post_shielded = Decimal(post_balance['private'])
+        print("  Shielded balance: {} -> {} ZEC".format(pre_shielded, post_shielded))
+        assert_true(post_shielded > pre_shielded, "Shielded balance should increase after wildcard shielding")
+        print("  PASSED")
+
+        print("Test 9: Operation lifecycle...")
+        node.generate(COINBASE_MATURITY + 10)
+        time.sleep(5)
+
+        opid = wallet.z_shieldcoinbase("*", zaddr, None)
+        assert_true(opid.startswith("opid-"), "Expected opid format")
+
+        # z_getoperationstatus shows the operation without consuming it.
+        status_list = wallet.z_getoperationstatus([opid])
+        assert_equal(len(status_list), 1)
+        assert_equal(status_list[0]['id'], opid)
+        assert_true(
+            status_list[0]['status'] in ['queued', 'executing', 'success', 'failed'],
+            "Unexpected status: {}".format(status_list[0]['status'])
+        )
+
+        # z_getoperationresult waits for completion and consumes the result.
+        result = wait_and_assert_operationid_status_result(wallet, opid)
+        assert_equal(result['status'], 'success')
+        assert_true('txid' in result['result'], "Success result should contain txid")
+
+        # After z_getoperationresult, the operation should be cleared.
+        remaining = wallet.z_getoperationstatus([opid])
+        assert_equal(len(remaining), 0)
+        print("  PASSED")
+
+        print("Test 10: AllowRevealedSenders privacy policy...")
+        node.generate(COINBASE_MATURITY + 10)
+        time.sleep(5)
+
+        opid = wallet.z_shieldcoinbase("*", zaddr, None, None, None, "AllowRevealedSenders")
+        txid = wait_and_assert_operationid_status(wallet, opid)
+        assert_true(txid is not None, "Shielding with AllowRevealedSenders should succeed")
+
+        node.generate(1)
+        time.sleep(2)
+        print("  PASSED")
+
+        print("\nAll z_shieldcoinbase tests passed!")
+
+
+if __name__ == '__main__':
+    WalletZShieldCoinbaseTest().main()

--- a/qa/rpc-tests/wallet_z_shieldcoinbase.py
+++ b/qa/rpc-tests/wallet_z_shieldcoinbase.py
@@ -211,9 +211,9 @@ class WalletZShieldCoinbaseTest(BitcoinTestFramework):
         assert_true(Decimal(result['shieldingValue']) > Decimal('0'),
                     "Expected positive shielding value, got: {}".format(
                         result['shieldingValue']))
-        # `limit` is currently ignored by Zallet, so remainingUTXOs is
-        # always 0 on success. This invariant will change when limit is
-        # honored (https://github.com/zcash/wallet/issues/NNN).
+        # When `limit` is omitted, the proposal includes all eligible coinbase
+        # UTXOs, so `remainingUTXOs` is 0. Test 12 below exercises the case
+        # where `limit` truncates and `remainingUTXOs` is non-zero.
         assert_equal(result['remainingUTXOs'], 0)
         opid = result['opid']
         assert_true(isinstance(opid, str),
@@ -297,6 +297,85 @@ class WalletZShieldCoinbaseTest(BitcoinTestFramework):
         opid = result['opid']
         txid = wait_and_assert_operationid_status(wallet, opid)
         assert_true(txid is not None, "Shielding with AllowRevealedSenders should succeed")
+
+        node.generate(1)
+        wait_for_mature_coinbase(wallet)
+        print("  PASSED")
+
+        # ================================================================
+        # Honored-parameter tests (post-propose_shielding_coinbase integration)
+        # ================================================================
+        # Prior to https://github.com/zcash/wallet/pull/402, the `memo` and
+        # `limit` parameters were accepted but ignored. They are now honored.
+
+        print("Test 11: Memo propagation to Orchard...")
+        node.generate(COINBASE_MATURITY + 10)
+        wait_for_mature_coinbase(wallet)
+
+        # Use a 1024-character hex memo (= 512 bytes), padded with zeros.
+        # The leading bytes spell "c0ffee" in ASCII.
+        my_memo = '633066666565' + '0' * (1024 - 12)
+
+        result = wallet.z_shieldcoinbase("*", zaddr, None, None, my_memo)
+        opid = result['opid']
+        txid = wait_and_assert_operationid_status(wallet, opid)
+        assert_true(txid is not None, "Shielding with memo should succeed")
+
+        node.generate(1)
+        wait_for_mature_coinbase(wallet)
+
+        # Look up the transaction's decrypted outputs and verify the memo
+        # arrived. This exercises Zallet's Orchard branch of
+        # `z_viewtransaction`; if memo retrieval for Orchard outputs is not
+        # yet supported, the test should be downgraded to a Sapling
+        # destination (see `wallet.z_getaddressforaccount(0, ["sapling"])`).
+        tx_details = wallet.z_viewtransaction(txid)
+        shielded_outputs = [o for o in tx_details['outputs']
+                            if o.get('pool') in ('sapling', 'orchard')]
+        assert_true(
+            len(shielded_outputs) >= 1,
+            "Expected at least one shielded output, got: {}".format(tx_details)
+        )
+        # `z_shieldcoinbase` routes everything into a single shielded
+        # payment, so the memo should be attached to that payment.
+        assert_equal(
+            shielded_outputs[0]['memo'], my_memo,
+            "Memo should propagate to the shielded note"
+        )
+        print("  PASSED")
+
+        print("Test 12: Limit truncation...")
+        # Need enough mature coinbase UTXOs to actually exercise truncation.
+        node.generate(COINBASE_MATURITY + 30)
+        wait_for_mature_coinbase(wallet, min_mature_utxos=10)
+
+        utxos_before = wallet.z_listunspent(COINBASE_MATURITY + 1)
+        transparent_before = [u for u in utxos_before if u.get('pool') == 'transparent']
+        n_eligible = len(transparent_before)
+        assert_true(
+            n_eligible >= 5,
+            "Need at least 5 mature coinbase UTXOs to test limit truncation, "
+            "got {}".format(n_eligible)
+        )
+
+        limit = 3
+        result = wallet.z_shieldcoinbase("*", zaddr, None, limit)
+        assert_equal(
+            result['shieldingUTXOs'], limit,
+            "Should select exactly `limit` UTXOs, got {}".format(result['shieldingUTXOs'])
+        )
+        assert_equal(
+            result['remainingUTXOs'], n_eligible - limit,
+            "Should leave the rest as remaining, got {}".format(result['remainingUTXOs'])
+        )
+        assert_true(
+            Decimal(result['remainingValue']) > Decimal('0'),
+            "Should have non-zero remaining value"
+        )
+
+        opid = result['opid']
+        txid = wait_and_assert_operationid_status(wallet, opid)
+        assert_true(txid is not None, "Limited shielding should succeed")
 
         node.generate(1)
         wait_for_mature_coinbase(wallet)

--- a/qa/rpc-tests/wallet_z_shieldcoinbase.py
+++ b/qa/rpc-tests/wallet_z_shieldcoinbase.py
@@ -30,6 +30,43 @@ from test_framework.util import (
 COINBASE_MATURITY = 100
 
 
+def wait_for_mature_coinbase(wallet, min_mature_utxos=1, timeout=120):
+    """
+    Wait until the wallet has indexed at least `min_mature_utxos` mature
+    coinbase UTXOs spendable via `z_shieldcoinbase`.
+
+    Zallet's `z_gettotalbalance` and `z_listunspent` reflect only what the
+    wallet has scanned and committed to its local SQLite database. After
+    `node.generate(N)`, there is a non-trivial delay (block fetch + scan +
+    commit) before those views update. The framework's `sync_all` only
+    synchronizes nodes, not wallets, and no `getwalletstatus` RPC is
+    available yet (https://github.com/zcash/wallet/issues/316).
+
+    Polls `z_listunspent(minconf=COINBASE_MATURITY + 1)` once per second.
+    Considered ready when at least `min_mature_utxos` transparent outputs
+    are visible at that confirmation depth.
+    """
+    deadline = time.time() + timeout
+    last_count = 0
+    while time.time() < deadline:
+        try:
+            utxos = wallet.z_listunspent(COINBASE_MATURITY + 1)
+            transparent = [u for u in utxos if u.get('pool') == 'transparent']
+            last_count = len(transparent)
+            if last_count >= min_mature_utxos:
+                return
+        except Exception:
+            pass
+        time.sleep(1)
+
+    raise AssertionError(
+        "wait_for_mature_coinbase: timeout after {}s; only saw {} mature "
+        "transparent UTXOs (wanted {})".format(
+            timeout, last_count, min_mature_utxos
+        )
+    )
+
+
 class WalletZShieldCoinbaseTest(BitcoinTestFramework):
 
     def __init__(self):
@@ -62,7 +99,7 @@ class WalletZShieldCoinbaseTest(BitcoinTestFramework):
         # Mine enough blocks so that the earliest coinbase UTXOs have
         # more than 100 confirmations.
         node.generate(COINBASE_MATURITY + 20)
-        time.sleep(10)
+        wait_for_mature_coinbase(wallet, min_mature_utxos=10)
 
         # Verify the wallet sees the transparent balance.
         wallet_balance = wallet.z_gettotalbalance(1, True)
@@ -159,17 +196,39 @@ class WalletZShieldCoinbaseTest(BitcoinTestFramework):
         # ================================================================
 
         print("Test 7: Basic shielding (explicit taddr -> Orchard UA)...")
-        opid = wallet.z_shieldcoinbase(miner_taddr, zaddr, None)
-        assert_true(isinstance(opid, str), "Expected opid string, got: {}".format(type(opid)))
-        assert_true(opid.startswith("opid-"), "Expected opid to start with 'opid-', got: {}".format(opid))
+        result = wallet.z_shieldcoinbase(miner_taddr, zaddr, None)
+        # The pre-flight return shape matches zcashd:
+        # { remainingUTXOs, remainingValue, shieldingUTXOs, shieldingValue, opid }
+        assert_true(isinstance(result, dict),
+                    "Expected response object, got: {}".format(type(result)))
+        for key in ('remainingUTXOs', 'remainingValue', 'shieldingUTXOs',
+                    'shieldingValue', 'opid'):
+            assert_true(key in result,
+                        "Missing field '{}' in response: {}".format(key, result))
+        assert_true(result['shieldingUTXOs'] > 0,
+                    "Expected at least one UTXO being shielded, got: {}".format(
+                        result['shieldingUTXOs']))
+        assert_true(Decimal(result['shieldingValue']) > Decimal('0'),
+                    "Expected positive shielding value, got: {}".format(
+                        result['shieldingValue']))
+        # `limit` is currently ignored by Zallet, so remainingUTXOs is
+        # always 0 on success. This invariant will change when limit is
+        # honored (https://github.com/zcash/wallet/issues/NNN).
+        assert_equal(result['remainingUTXOs'], 0)
+        opid = result['opid']
+        assert_true(isinstance(opid, str),
+                    "Expected opid string, got: {}".format(type(opid)))
+        assert_true(opid.startswith("opid-"),
+                    "Expected opid format, got: {}".format(opid))
 
         txid = wait_and_assert_operationid_status(wallet, opid)
         assert_true(txid is not None, "Shielding transaction should have succeeded")
         print("  Shielding tx: {}".format(txid))
 
-        # Mine a block to confirm the shielding transaction.
+        # Mine a block to confirm the shielding transaction, then wait for
+        # the wallet to scan it.
         node.generate(1)
-        time.sleep(3)
+        wait_for_mature_coinbase(wallet)
 
         # Verify the wallet sees the shielded balance.
         wallet_balance = wallet.z_gettotalbalance(1, True)
@@ -181,18 +240,21 @@ class WalletZShieldCoinbaseTest(BitcoinTestFramework):
         print("Test 8: Wildcard shielding (* -> Orchard UA)...")
         # Mine blocks to create AND mature new coinbase UTXOs.
         node.generate(COINBASE_MATURITY + 10)
-        time.sleep(5)
+        wait_for_mature_coinbase(wallet)
 
         pre_balance = wallet.z_gettotalbalance(1, True)
         pre_shielded = Decimal(pre_balance['private'])
 
-        opid = wallet.z_shieldcoinbase("*", zaddr, None)
+        result = wallet.z_shieldcoinbase("*", zaddr, None)
+        opid = result['opid']
+        assert_true(result['shieldingUTXOs'] > 0,
+                    "Expected wildcard shielding to select UTXOs")
         txid = wait_and_assert_operationid_status(wallet, opid)
         assert_true(txid is not None, "Wildcard shielding should have succeeded")
         print("  Wildcard shielding tx: {}".format(txid))
 
         node.generate(1)
-        time.sleep(3)
+        wait_for_mature_coinbase(wallet)
 
         post_balance = wallet.z_gettotalbalance(1, True)
         post_shielded = Decimal(post_balance['private'])
@@ -202,9 +264,10 @@ class WalletZShieldCoinbaseTest(BitcoinTestFramework):
 
         print("Test 9: Operation lifecycle...")
         node.generate(COINBASE_MATURITY + 10)
-        time.sleep(5)
+        wait_for_mature_coinbase(wallet)
 
-        opid = wallet.z_shieldcoinbase("*", zaddr, None)
+        result = wallet.z_shieldcoinbase("*", zaddr, None)
+        opid = result['opid']
         assert_true(opid.startswith("opid-"), "Expected opid format")
 
         # z_getoperationstatus shows the operation without consuming it.
@@ -228,14 +291,15 @@ class WalletZShieldCoinbaseTest(BitcoinTestFramework):
 
         print("Test 10: AllowRevealedSenders privacy policy...")
         node.generate(COINBASE_MATURITY + 10)
-        time.sleep(5)
+        wait_for_mature_coinbase(wallet)
 
-        opid = wallet.z_shieldcoinbase("*", zaddr, None, None, None, "AllowRevealedSenders")
+        result = wallet.z_shieldcoinbase("*", zaddr, None, None, None, "AllowRevealedSenders")
+        opid = result['opid']
         txid = wait_and_assert_operationid_status(wallet, opid)
         assert_true(txid is not None, "Shielding with AllowRevealedSenders should succeed")
 
         node.generate(1)
-        time.sleep(2)
+        wait_for_mature_coinbase(wallet)
         print("  PASSED")
 
         print("\nAll z_shieldcoinbase tests passed!")


### PR DESCRIPTION
## Summary

Adds an integration test suite for Zallet's `z_shieldcoinbase` RPC method against the Z3 stack (zebrad + zaino + zallet). Covers the full honored-parameter surface after the [librustzcash `propose_shielding_coinbase` integration](https://github.com/zcash/wallet/pull/402).

## Coverage

12 tests in `qa/rpc-tests/wallet_z_shieldcoinbase.py`:

**Error handling (Tests 1–6):**
- Fee must be null
- Invalid `toaddress` (transparent rejected)
- Invalid `fromaddress`
- Shielded `fromaddress` rejected
- `LegacyCompat` privacy policy rejected
- Same-account enforcement

**Functional (Tests 7–10):**
- Basic shielding (explicit taddr → Orchard UA), verifies the zcashd-shape pre-flight response (`{ remainingUTXOs, remainingValue, shieldingUTXOs, shieldingValue, opid }`)
- Wildcard shielding (`*` → Orchard UA)
- Operation lifecycle (`z_getoperationstatus` / `z_getoperationresult`)
- `AllowRevealedSenders` privacy policy

**Honored parameters (Tests 11–12, new):**
- **Memo propagation**: supplies a 1024-character hex memo, shields to an Orchard UA, looks up the transaction via `z_viewtransaction`, and verifies the memo arrives in the resulting shielded note's memo field. Currently exercises Orchard; if Zallet's `z_viewtransaction` doesn't yet expose memos for Orchard outputs the test should be downgraded to a Sapling destination as a follow-up.
- **Limit truncation**: with more than `n` mature coinbase UTXOs and `limit=3`, verifies the proposal selects exactly 3 UTXOs and reports the remainder via `remainingUTXOs` / `remainingValue`.

## Notes

- Uses 1 node + 1 wallet to avoid a Zaino race condition with concurrent wallets.
- The custom `wait_for_mature_coinbase` polling helper works around the lack of a `getwalletstatus` RPC ([wallet#316](https://github.com/zcash/wallet/issues/316)) — the framework's `sync_all` synchronizes nodes only, not wallets.
- Listed under `NEW_SCRIPTS` in `qa/pull-tester/rpc-tests.py` (the "Tests less than 60s" bucket), to keep it grouped with other migrated/new tests during the legacy-test triage period.