### PR TITLE
ci: make SERIAL/FLAKY RPC shards non-required

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -210,6 +210,7 @@ jobs:
       - id: set-rpc-tests
         env:
           IS_INTEROP_REQUEST: ${{ endsWith(github.event.action, '-interop-request') }}
+          RPC_TEST_MATRIX: ${{ steps.set-matrices.outputs.rpc_test_matrix }}
         run: |
           cat <<EOF > ./subclass.py
           import importlib
@@ -275,7 +276,8 @@ jobs:
           # Strip required/required_suffix from the platform object: for RPC tests
           # the required flag is carried per-shard (set in subclass.py above), so the
           # platform object must not blanket-stamp every shard as required.
-          RPC_MATRIX_JSON=$(echo '${{ steps.set-matrices.outputs.rpc_test_matrix }}' | jq -c 'map(del(.required, .required_suffix))')
+          # RPC_TEST_MATRIX is passed via env (not inline ${{ }}) to avoid template injection.
+          RPC_MATRIX_JSON=$(echo "$RPC_TEST_MATRIX" | jq -c 'map(del(.required, .required_suffix))')
           RPC_SHARDS_JSON=$(SRC_DIR=$(pwd) python3 ./subclass.py)
           echo "$RPC_SHARDS_JSON" | jq -r '[.[] | .shard] | @json "rpc_test_shards=\(.)"' >> $GITHUB_OUTPUT
           echo -e "$RPC_MATRIX_JSON\n$RPC_SHARDS_JSON" | jq -r -s 'add | @json "rpc_test_shards_matrix=\(.)"' >> $GITHUB_OUTPUT

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -251,21 +251,31 @@ jobs:
               test_list.append({
                   'shard': 'shard-%d' % i,
                   'rpc_tests': tests,
+                  'required': True,
+                  'required_suffix': ' (required)',
               })
 
           # These tests involve enough shielded spends (consuming all CPU cores)
           # that we can't run them in parallel, or fail intermittently so we run
-          # them separately to enable not requiring that they pass.
+          # them separately to enable not requiring that they pass. We mark them
+          # required=False here so their shards are non-blocking; the per-shard
+          # required flag is the single source of truth (the platform object's
+          # required flag is stripped before the matrix merge, below).
           if not is_interop_request:
               for test in rpc_tests.SERIAL_SCRIPTS + rpc_tests.FLAKY_SCRIPTS:
                   test_list.append({
                       'shard': test,
                       'rpc_tests': [test],
+                      'required': False,
+                      'required_suffix': '',
                   })
 
           print(json.dumps(test_list))
           EOF
-          RPC_MATRIX_JSON=$(echo '${{ steps.set-matrices.outputs.rpc_test_matrix }}')
+          # Strip required/required_suffix from the platform object: for RPC tests
+          # the required flag is carried per-shard (set in subclass.py above), so the
+          # platform object must not blanket-stamp every shard as required.
+          RPC_MATRIX_JSON=$(echo '${{ steps.set-matrices.outputs.rpc_test_matrix }}' | jq -c 'map(del(.required, .required_suffix))')
           RPC_SHARDS_JSON=$(SRC_DIR=$(pwd) python3 ./subclass.py)
           echo "$RPC_SHARDS_JSON" | jq -r '[.[] | .shard] | @json "rpc_test_shards=\(.)"' >> $GITHUB_OUTPUT
           echo -e "$RPC_MATRIX_JSON\n$RPC_SHARDS_JSON" | jq -r -s 'add | @json "rpc_test_shards_matrix=\(.)"' >> $GITHUB_OUTPUT

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -276,7 +276,8 @@ jobs:
           # Strip required/required_suffix from the platform object: for RPC tests
           # the required flag is carried per-shard (set in subclass.py above), so the
           # platform object must not blanket-stamp every shard as required.
-          # RPC_TEST_MATRIX is passed via env (not inline ${{ }}) to avoid template injection.
+          # RPC_TEST_MATRIX is passed via env (not inlined into this script) to avoid
+          # GitHub Actions template injection.
           RPC_MATRIX_JSON=$(echo "$RPC_TEST_MATRIX" | jq -c 'map(del(.required, .required_suffix))')
           RPC_SHARDS_JSON=$(SRC_DIR=$(pwd) python3 ./subclass.py)
           echo "$RPC_SHARDS_JSON" | jq -r '[.[] | .shard] | @json "rpc_test_shards=\(.)"' >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Problem

`main` CI shows the required-checks rollup as **red**. The RPC-tests job builds its matrix as `name × shard` and then `include`s a platform object that carries `required: true` / `required_suffix: " (required)"`. Because the required flag rides on the **platform** axis (`ubuntu-22.04`), it gets stamped onto **every** shard — including the SERIAL/FLAKY per-test shards that are *meant* to be non-blocking (`subclass.py` already says they're split out "to enable not requiring that they pass"). They end up `required: true`, `continue-on-error: false`, and their failures gate the rollup.

## Fix

Make the `required` flag a **per-shard** property (single source of truth) instead of a per-platform one, in the `set-rpc-tests` step:

- `shard-0…9` (the BASE/NEW/ZMQ tests): `required: true`.
- SERIAL/FLAKY per-test shards: `required: false`, `required_suffix: ''`.
- Strip `required`/`required_suffix` from the platform object in the local merge so it no longer blanket-stamps every shard.

No test logic changes. The `interop-request` path is unchanged (SERIAL/FLAKY aren't added there, so all shards stay required).

## Status / coordination (updated 2026-06-05)

This PR is the **CI-matrix mechanism** and is correct as-is, but two things have changed since it was opened — read before merging:

1. **It does not go green on its own yet.** The *required* shards (`shard-0…9`) currently fail too, because cache rebuild (`create_cache.py`) crashes on an **upstream** zallet bug: `Failed to synchronize zallet: InvalidData { "Missing Orchard tree state" }` (zcash/wallet#454, fixed by zcash/wallet#455, not yet merged). Until #455 lands, the rollup stays red regardless of this PR.
2. **Pairs with #102.** Without #102's bounded waits, that upstream crash makes a shard hang for the full **6-hour** runner limit instead of failing fast. #102 should land first so this PR's failures are legible.

**Relationship to #104:** the six tests failing today (`mergetoaddress_{sapling,ua_nu5,ua_sapling}`, `wallet_shieldingcoinbase`, `mempool_nu_activation`, `mempool_packages`) are **deterministically broken**, not flaky — they pass zcashd-style arg lists that the Z3 stack rejects at setup. The plan is to move those into #104's `DISABLED_SCRIPTS` (don't run them; document per-test migration need), and keep this PR's per-shard `required` mechanism as the correct foundation and the home for *genuinely intermittent* quarantines. So #101 and #104 are **complementary, layered** — not competing.

## Verification

Locally simulated the modified matrix generator (extracted verbatim from this file's heredoc): 10 `required=true` shards (`shard-0 … shard-9`) and the SERIAL/FLAKY shards as `required=false`. Interop path (`IS_INTEROP_REQUEST=true`) still yields 10 required shards and no SERIAL/FLAKY entries.