### PR TITLE
wallet.py: add sync barriers to fix flaky wallet-scan race

### DIFF
--- a/qa/rpc-tests/wallet.py
+++ b/qa/rpc-tests/wallet.py
@@ -10,6 +10,29 @@ import time
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import assert_equal, assert_true
 
+
+def wait_for_wallet_transparent(wallet, expected, timeout=60):
+    # z_gettotalbalance reflects only blocks the wallet has scanned and committed; after
+    # mining there is a delay before that view catches up. Poll for the expected value
+    # instead of racing it (there is no synchronous wallet-sync RPC yet, zcash/wallet#316).
+    deadline = time.time() + timeout
+    balance = wallet.z_gettotalbalance(1, True)['transparent']
+    while balance != expected and time.time() < deadline:
+        time.sleep(0.5)
+        balance = wallet.z_gettotalbalance(1, True)['transparent']
+    return balance
+
+
+def wait_for_wallet_txcount(wallet, expected, timeout=60):
+    # Same sync barrier, for the wallet's view of its transaction count.
+    deadline = time.time() + timeout
+    count = len(wallet.z_listtransactions())
+    while count != expected and time.time() < deadline:
+        time.sleep(0.5)
+        count = len(wallet.z_listtransactions())
+    return count
+
+
 # Test that we can create a wallet and use an address from it to mine blocks.
 class WalletTest (BitcoinTestFramework):
 
@@ -26,7 +49,8 @@ class WalletTest (BitcoinTestFramework):
         node_balance = self.nodes[0].getaddressbalance(transparent_address)
         assert_equal(node_balance['balance'], 625000000)
 
-        # Zallet can see the balance.
+        # Zallet can see the balance, once it has scanned the coinbase block.
+        wait_for_wallet_transparent(self.wallets[0], '6.25000000')
         wallet_balance = self.wallets[0].z_gettotalbalance(1, True)
         # TODO: Result is a string (https://github.com/zcash/wallet/issues/15)
         assert_equal(wallet_balance['transparent'], '6.25000000')
@@ -34,13 +58,11 @@ class WalletTest (BitcoinTestFramework):
         # Mine another block
         self.nodes[0].generate(1)
 
-        # Wait for the wallet to sync
-        time.sleep(1)
-
         node_balance = self.nodes[0].getaddressbalance(transparent_address)
         assert_equal(node_balance['balance'], 1250000000)
 
-        # There are 2 transactions in the wallet
+        # There are 2 transactions in the wallet, once it has scanned the new block.
+        wait_for_wallet_txcount(self.wallets[0], 2)
         assert_equal(len(self.wallets[0].z_listtransactions()), 2)
 
         # Confirmed balance in the wallet is either 6.25 or 12.5 ZEC


### PR DESCRIPTION
Closes #105

### Motivation

`wallet.py` reads wallet state (`z_gettotalbalance` / `z_listtransactions`)
immediately after mining, before the embedded wallet has scanned and committed
the newly mined blocks. The transparent-balance assertion races the asynchronous
wallet scan and intermittently fails with `0` instead of the expected `6.25`.

There is no synchronous "wallet has synced to height N" RPC to await yet
(tracked upstream in zcash/wallet#316), so the test must poll for the expected
wallet view rather than assuming immediate consistency after mining.

### Solution

Add poll-barriers before the wallet-side assertions:
- `wait_for_wallet_transparent` — wait until the transparent balance reflects the
  matured coinbase.
- `wait_for_wallet_txcount` — wait until the wallet observes the expected number
  of transactions.

This mirrors the sync-barrier idiom already used in the migrated tests. No test
logic or coverage is changed — only the ordering guarantee that the wallet has
scanned before we assert on its view.

### Test evidence

Run locally against zebrad + zainod + zallet (the zallet built with the
zcash/wallet#455 fix so sync reaches the wallet-scan stage):

`wallet.py` passes **3/3 consecutive runs** (~7-8s each, exit 0,
"Missing Orchard tree state" = 0). Without the barriers the transparent-balance
assertion fails intermittently (0 vs 6.25).

### Notes

- Depends on nothing in this repo; off `main` (the #100 merge).
- The masking sync crash that previously hid this race is fixed upstream by
  zcash/wallet#455 (Closes zcash/wallet#454) — independent of this change.
