### PR TITLE
Rename legacy node helpers to match the Z3 stack

### DIFF
--- a/qa/rpc-tests/show_help.py
+++ b/qa/rpc-tests/show_help.py
@@ -9,7 +9,7 @@
 #
 
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import assert_equal, zcashd_binary
+from test_framework.util import assert_equal, zebrad_binary
 
 from difflib import SequenceMatcher, unified_diff
 import subprocess
@@ -615,7 +615,7 @@ class ShowHelpTest(BitcoinTestFramework):
 
     def show_help(self, expected, extra_args):
         with tempfile.SpooledTemporaryFile(max_size=2**16) as log_stdout:
-            args = [ zcashd_binary(), "--help" ] + extra_args
+            args = [ zebrad_binary(), "--help" ] + extra_args
             process = subprocess.run(args, stdout=log_stdout)
             assert_equal(process.returncode, 0)
             log_stdout.seek(0)

--- a/qa/rpc-tests/test_framework/test_framework.py
+++ b/qa/rpc-tests/test_framework/test_framework.py
@@ -18,7 +18,7 @@ import traceback
 from .config import ZebraArgs
 from .proxy import JSONRPCException
 from .util import (
-    zcashd_binary,
+    zebrad_binary,
     initialize_chain,
     prepare_wallets_for_mining,
     start_nodes,
@@ -260,10 +260,10 @@ class ComparisonTestFramework(BitcoinTestFramework):
 
     def add_options(self, parser):
         parser.add_option("--testbinary", dest="testbinary",
-                          default=zcashd_binary(),
+                          default=zebrad_binary(),
                           help="zebrad binary to test")
         parser.add_option("--refbinary", dest="refbinary",
-                          default=zcashd_binary(),
+                          default=zebrad_binary(),
                           help="zebrad binary to use for reference nodes (if any)")
 
     def setup_network(self):

--- a/qa/rpc-tests/test_framework/util.py
+++ b/qa/rpc-tests/test_framework/util.py
@@ -54,7 +54,7 @@ PORT_MIN = 11000
 # The number of ports to "reserve" for p2p, rpc and wallet rpc each
 PORT_RANGE = 5000
 
-def zcashd_binary():
+def zebrad_binary():
     return os.getenv("ZEBRAD", os.path.join("src", "zebrad"))
 
 def zaino_binary():
@@ -261,7 +261,7 @@ def rpc_zaino_url(i, rpchost=None):
 # fails fast and surfaces the cause. Override with the PROC_START_TIMEOUT env var.
 PROC_START_TIMEOUT = int(os.getenv("PROC_START_TIMEOUT", "120"))
 
-def wait_for_bitcoind_start(process, url, i):
+def wait_for_zebrad_start(process, url, i):
     '''
     Wait for bitcoind to start. This means that RPC is accessible and fully initialized.
     Raise an exception if bitcoind exits during initialization, or fails to become
@@ -270,9 +270,9 @@ def wait_for_bitcoind_start(process, url, i):
     deadline = time.time() + PROC_START_TIMEOUT
     while True:
         if process.poll() is not None:
-            raise Exception('%s node %d exited with status %i during initialization' % (zcashd_binary(), i, process.returncode))
+            raise Exception('%s node %d exited with status %i during initialization' % (zebrad_binary(), i, process.returncode))
         if time.time() > deadline:
-            raise Exception('%s node %d failed to become ready within %d seconds' % (zcashd_binary(), i, PROC_START_TIMEOUT))
+            raise Exception('%s node %d failed to become ready within %d seconds' % (zebrad_binary(), i, PROC_START_TIMEOUT))
         try:
             rpc = get_rpc_proxy(url, i)
             rpc.getblockcount()
@@ -352,12 +352,12 @@ def initialize_chain(test_dir, num_nodes, cachedir, cache_behavior='current'):
             config = update_zebrad_conf(datadir, rpc_port(i), p2p_port(i), indexer_rpc_port(i), ZebraArgs(
                 miner_address=miner_addresses[i],
             ))
-            args = [ zcashd_binary(), "-c="+config, "start" ]
+            args = [ zebrad_binary(), "-c="+config, "start" ]
 
             bitcoind_processes[i] = subprocess.Popen(args)
             if os.getenv("PYTHON_DEBUG", ""):
-                print("initialize_chain: %s started, waiting for RPC to come up" % (zcashd_binary(),))
-            wait_for_bitcoind_start(bitcoind_processes[i], rpc_url(i), i)
+                print("initialize_chain: %s started, waiting for RPC to come up" % (zebrad_binary(),))
+            wait_for_zebrad_start(bitcoind_processes[i], rpc_url(i), i)
             if os.getenv("PYTHON_DEBUG", ""):
                 print("initialize_chain: RPC successfully started")
 
@@ -400,11 +400,11 @@ def initialize_chain(test_dir, num_nodes, cachedir, cache_behavior='current'):
                 wait_bitcoinds()
                 for i in range(MAX_NODES):
                     config = zebrad_config(node_dir(cachedir, i))
-                    args = [ zcashd_binary(), "-c="+config, "start" ]
+                    args = [ zebrad_binary(), "-c="+config, "start" ]
                     bitcoind_processes[i] = subprocess.Popen(args)
                     if os.getenv("PYTHON_DEBUG", ""):
-                        print("initialize_chain: %s started, waiting for RPC to come up" % (zcashd_binary(),))
-                    wait_for_bitcoind_start(bitcoind_processes[i], rpc_url(i), i)
+                        print("initialize_chain: %s started, waiting for RPC to come up" % (zebrad_binary(),))
+                    wait_for_zebrad_start(bitcoind_processes[i], rpc_url(i), i)
                     if os.getenv("PYTHON_DEBUG", ""):
                         print("initialize_chain: RPC successfully started")
                 for i in range(MAX_NODES):
@@ -623,7 +623,7 @@ def start_node(i, dirname, extra_args=None, rpchost=None, timewait=None, binary=
     """
     datadir = node_dir(dirname, i)
     if binary is None:
-        binary = zcashd_binary()
+        binary = zebrad_binary()
     config = update_zebrad_conf(datadir, rpc_port(i), p2p_port(i), indexer_rpc_port(i), extra_args)
     args = [ binary, "-c="+config, "start" ]
 
@@ -631,7 +631,7 @@ def start_node(i, dirname, extra_args=None, rpchost=None, timewait=None, binary=
     if os.getenv("PYTHON_DEBUG", ""):
         print("start_node: bitcoind started, waiting for RPC to come up")
     url = rpc_url(i, rpchost)
-    wait_for_bitcoind_start(bitcoind_processes[i], url, i)
+    wait_for_zebrad_start(bitcoind_processes[i], url, i)
     if os.getenv("PYTHON_DEBUG", ""):
         print("start_node: RPC successfully started for node {} with pid {}".format(i, bitcoind_processes[i].pid))
     proxy = get_rpc_proxy(url, i, timeout=timewait)
@@ -647,7 +647,7 @@ def assert_start_raises_init_error(i, dirname, extra_args=None, expected_msg=Non
             node = start_node(i, dirname, extra_args, stderr=log_stderr)
             stop_node(node, i)
         except Exception as e:
-            assert ("%s node %d exited" % (zcashd_binary(), i)) in str(e) # node must have shutdown
+            assert ("%s node %d exited" % (zebrad_binary(), i)) in str(e) # node must have shutdown
             if expected_msg is not None:
                 log_stderr.seek(0)
                 stderr = log_stderr.read().decode('utf-8')
@@ -655,9 +655,9 @@ def assert_start_raises_init_error(i, dirname, extra_args=None, expected_msg=Non
                     raise AssertionError("Expected error \"" + expected_msg + "\" not found in:\n" + stderr)
         else:
             if expected_msg is None:
-                assert_msg = "%s should have exited with an error" % (zcashd_binary(),)
+                assert_msg = "%s should have exited with an error" % (zebrad_binary(),)
             else:
-                assert_msg = "%s should have exited with expected error %r" % (zcashd_binary(), expected_msg)
+                assert_msg = "%s should have exited with expected error %r" % (zebrad_binary(), expected_msg)
             raise AssertionError(assert_msg)
 
 def start_nodes(num_nodes, dirname, extra_args=None, rpchost=None, binary=None):


### PR DESCRIPTION
Feel free to close if you disagree with the renaming - don't lose much time reading if it is contraversary, I don't have a strong opinion. This is an automated patch generated by Claude in the background while onboarding on the code.

---

The RPC test framework descends from Bitcoin Core via zcashd, so its node
helper kept the inherited name even though the node is now zebrad. This
renames the two framework-internal helpers to match the existing
`zaino_binary` / `zallet_binary` and `wait_for_zainod_start` /
`wait_for_wallet_start` naming:

- `zcashd_binary` -> `zebrad_binary`
- `wait_for_bitcoind_start` -> `wait_for_zebrad_start`

Internal-only change, touching `util.py`, `test_framework.py` and
`show_help.py`.

Deliberately left unchanged to stay close to the upstream framework these
tests are imported from:

- the widely-used public API names (`BitcoinTestFramework`, `start_node`/
  `start_nodes`, `bitcoind_processes`, `wait_bitcoinds`)
- the `ZCASHD_BINARY` constant still referenced by a few not-yet-migrated
  EXTENDED tests

Verified locally: `getmininginfo.py` still passes (node startup goes through
the renamed helpers).

Part of #109.