### PR TITLE
Rename the bitcoind-era public test-framework API to Z3 names

### DIFF
--- a/qa/rpc-tests/addnode.py
+++ b/qa/rpc-tests/addnode.py
@@ -3,10 +3,10 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://www.opensource.org/licenses/mit-license.php .
 
-from test_framework.test_framework import BitcoinTestFramework
+from test_framework.test_framework import ZcashTestFramework
 from test_framework.util import assert_equal, connect_nodes_bi
 
-class AddNodeTest (BitcoinTestFramework):
+class AddNodeTest (ZcashTestFramework):
 
     def __init__(self):
         super().__init__()

--- a/qa/rpc-tests/addressindex.py
+++ b/qa/rpc-tests/addressindex.py
@@ -14,14 +14,14 @@
 #   getaddressmempool
 
 
-from test_framework.test_framework import BitcoinTestFramework
+from test_framework.test_framework import ZcashTestFramework
 
 from test_framework.util import (
     assert_equal,
     start_nodes,
     stop_nodes,
     connect_nodes,
-    wait_bitcoinds
+    wait_nodes
 )
 
 from test_framework.script import (
@@ -43,7 +43,7 @@ from test_framework.mininode import (
 from binascii import hexlify, unhexlify
 
 
-class AddressIndexTest(BitcoinTestFramework):
+class AddressIndexTest(ZcashTestFramework):
 
     def __init__(self):
         super().__init__()
@@ -171,7 +171,7 @@ class AddressIndexTest(BitcoinTestFramework):
 
         # Restart all nodes to ensure indices are saved to disk and recovered
         stop_nodes(self.nodes)
-        wait_bitcoinds()
+        wait_nodes()
         self.setup_network()
 
         bal = self.nodes[1].getaddressbalance(addr1)

--- a/qa/rpc-tests/blockchain.py
+++ b/qa/rpc-tests/blockchain.py
@@ -11,12 +11,12 @@
 
 import decimal
 
-from test_framework.test_framework import BitcoinTestFramework
+from test_framework.test_framework import ZcashTestFramework
 from test_framework.util import (
     assert_equal,
 )
 
-class BlockchainTest(BitcoinTestFramework):
+class BlockchainTest(ZcashTestFramework):
     """
     Test blockchain-related RPC calls:
 

--- a/qa/rpc-tests/coinbase_funding_streams.py
+++ b/qa/rpc-tests/coinbase_funding_streams.py
@@ -5,7 +5,7 @@
 
 from decimal import Decimal
 
-from test_framework.test_framework import BitcoinTestFramework
+from test_framework.test_framework import ZcashTestFramework
 from test_framework.blocktools import create_block, create_coinbase
 from test_framework.mininode import (
     fundingstream,
@@ -20,7 +20,7 @@ from test_framework.script import (
 )
 from test_framework.util import (
     assert_equal,
-    bitcoind_processes,
+    node_processes,
     connect_nodes,
     start_node,
     BLOSSOM_BRANCH_ID,
@@ -41,7 +41,7 @@ def redeem_script(addr):
 
     raise ValueError("unrecognized address type")
 
-class CoinbaseFundingStreamsTest(BitcoinTestFramework):
+class CoinbaseFundingStreamsTest(ZcashTestFramework):
     def __init__(self):
         super().__init__()
         self.num_nodes = 2
@@ -88,9 +88,9 @@ class CoinbaseFundingStreamsTest(BitcoinTestFramework):
 
         # Restart both nodes with funding streams.
         self.nodes[0].stop()
-        bitcoind_processes[0].wait()
+        node_processes[0].wait()
         self.nodes[1].stop()
-        bitcoind_processes[1].wait()
+        node_processes[1].wait()
         new_args = [
             "-mineraddress=%s" % miner_addr,
             "-minetolocalwallet=0",

--- a/qa/rpc-tests/converttex.py
+++ b/qa/rpc-tests/converttex.py
@@ -3,13 +3,13 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://www.opensource.org/licenses/mit-license.php .
 
-from test_framework.test_framework import BitcoinTestFramework
+from test_framework.test_framework import ZcashTestFramework
 from test_framework.util import (
     assert_equal,
 )
 
 
-class ConvertTEXTest(BitcoinTestFramework):
+class ConvertTEXTest(ZcashTestFramework):
     '''
     Test that the `z_converttex` RPC method correctly converts transparent
     addresses to ZIP 320 TEX addresses.

--- a/qa/rpc-tests/create_cache.py
+++ b/qa/rpc-tests/create_cache.py
@@ -6,12 +6,12 @@
 
 #
 # Helper script to create the cache
-# (see BitcoinTestFramework.setup_chain)
+# (see ZcashTestFramework.setup_chain)
 #
 
-from test_framework.test_framework import BitcoinTestFramework
+from test_framework.test_framework import ZcashTestFramework
 
-class CreateCache(BitcoinTestFramework):
+class CreateCache(ZcashTestFramework):
 
     def __init__(self):
         super().__init__()

--- a/qa/rpc-tests/decodescript.py
+++ b/qa/rpc-tests/decodescript.py
@@ -4,14 +4,14 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://www.opensource.org/licenses/mit-license.php .
 
-from test_framework.test_framework import BitcoinTestFramework
+from test_framework.test_framework import ZcashTestFramework
 from test_framework.util import assert_equal, \
     hex_str_to_bytes, bytes_to_hex_str
 from test_framework.mininode import CTransaction
 from io import BytesIO
 
 
-class DecodeScriptTest(BitcoinTestFramework):
+class DecodeScriptTest(ZcashTestFramework):
     """Tests decoding scripts via RPC command "decodescript"."""
 
     def __init__(self):

--- a/qa/rpc-tests/disablewallet.py
+++ b/qa/rpc-tests/disablewallet.py
@@ -8,11 +8,11 @@
 # Exercise API with -disablewallet.
 #
 
-from test_framework.test_framework import BitcoinTestFramework
+from test_framework.test_framework import ZcashTestFramework
 from test_framework.util import start_nodes
 
 
-class DisableWalletTest (BitcoinTestFramework):
+class DisableWalletTest (ZcashTestFramework):
 
     def __init__(self):
         super().__init__()

--- a/qa/rpc-tests/errors.py
+++ b/qa/rpc-tests/errors.py
@@ -9,9 +9,9 @@
 #
 
 from test_framework.authproxy import JSONRPCException
-from test_framework.test_framework import BitcoinTestFramework
+from test_framework.test_framework import ZcashTestFramework
 
-class BlockchainTest(BitcoinTestFramework):
+class BlockchainTest(ZcashTestFramework):
     """
     Test RPC call failure cases.
     """

--- a/qa/rpc-tests/feature_backup_non_finalized_state.py
+++ b/qa/rpc-tests/feature_backup_non_finalized_state.py
@@ -3,12 +3,12 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://www.opensource.org/licenses/mit-license.php .
 
-from test_framework.test_framework import BitcoinTestFramework
+from test_framework.test_framework import ZcashTestFramework
 from test_framework.util import assert_equal, start_nodes
 import time
 
 # Test that Zebra can backup and restore non finalized state
-class BackupNonFinalized(BitcoinTestFramework):
+class BackupNonFinalized(ZcashTestFramework):
 
     def __init__(self):
         super().__init__()

--- a/qa/rpc-tests/feature_logging.py
+++ b/qa/rpc-tests/feature_logging.py
@@ -9,9 +9,9 @@ import os
 
 from test_framework.util import start_node, stop_node, assert_start_raises_init_error
 
-from test_framework.test_framework import BitcoinTestFramework
+from test_framework.test_framework import ZcashTestFramework
 
-class LoggingTest(BitcoinTestFramework):
+class LoggingTest(ZcashTestFramework):
     def set_test_params(self):
         self.num_nodes = 1
         self.num_wallets = 0

--- a/qa/rpc-tests/feature_nu6.py
+++ b/qa/rpc-tests/feature_nu6.py
@@ -7,7 +7,7 @@ from decimal import Decimal
 
 from test_framework.config import ZebraArgs
 
-from test_framework.test_framework import BitcoinTestFramework
+from test_framework.test_framework import ZcashTestFramework
 from test_framework.util import assert_equal, start_nodes
 
 # Check the behaviour of the value pools and funding streams at NU6.
@@ -16,7 +16,7 @@ from test_framework.util import assert_equal, start_nodes
 # - The lockbox pool and rewards are activated at NU6.
 # - The lockbox accumulates after NU6 inside the configured range.
 # - The lockbox rewrards and NU6 funding streams end after the configured range.
-class PoolsTest(BitcoinTestFramework):
+class PoolsTest(ZcashTestFramework):
 
     def __init__(self):
         super().__init__()

--- a/qa/rpc-tests/feature_nu6_1.py
+++ b/qa/rpc-tests/feature_nu6_1.py
@@ -5,7 +5,7 @@
 
 from decimal import Decimal
 
-from test_framework.test_framework import BitcoinTestFramework
+from test_framework.test_framework import ZcashTestFramework
 from test_framework.config import ZebraArgs
 from test_framework.util import (
     assert_equal,
@@ -13,7 +13,7 @@ from test_framework.util import (
 )
 
 # Verify the NU6.1 activation block contains the expected lockbox disbursement.
-class OnetimeLockboxDisbursementTest(BitcoinTestFramework):
+class OnetimeLockboxDisbursementTest(ZcashTestFramework):
 
     def __init__(self):
         super().__init__()

--- a/qa/rpc-tests/feature_walletfile.py
+++ b/qa/rpc-tests/feature_walletfile.py
@@ -9,9 +9,9 @@ import os
 
 from test_framework.util import start_node, stop_node, assert_start_raises_init_error
 
-from test_framework.test_framework import BitcoinTestFramework
+from test_framework.test_framework import ZcashTestFramework
 
-class WalletFileTest(BitcoinTestFramework):
+class WalletFileTest(ZcashTestFramework):
     def set_test_params(self):
         self.num_nodes = 1
         self.cache_behavior = 'clean'

--- a/qa/rpc-tests/feature_zip221.py
+++ b/qa/rpc-tests/feature_zip221.py
@@ -6,7 +6,7 @@
 
 from test_framework.flyclient import (ZcashMMRNode, append, delete, make_root_commitment)
 from test_framework.mininode import (CBlockHeader)
-from test_framework.test_framework import BitcoinTestFramework
+from test_framework.test_framework import ZcashTestFramework
 from test_framework.util import (
     BLOSSOM_BRANCH_ID,
     HEARTWOOD_BRANCH_ID,
@@ -25,7 +25,7 @@ NULL_FIELD = "00" * 32
 CHAIN_HISTORY_ROOT_VERSION = 2010200
 
 # Verify block header field 'hashLightClientRoot' is set correctly for Heartwood blocks.
-class Zip221Test(BitcoinTestFramework):
+class Zip221Test(ZcashTestFramework):
 
     def __init__(self):
         super().__init__()

--- a/qa/rpc-tests/feature_zip239.py
+++ b/qa/rpc-tests/feature_zip239.py
@@ -15,7 +15,7 @@ from test_framework.mininode import (
     msg_reject,
     uint256_from_reversed_hex,
 )
-from test_framework.test_framework import BitcoinTestFramework
+from test_framework.test_framework import ZcashTestFramework
 from test_framework.util import (
     BLOSSOM_BRANCH_ID,
     HEARTWOOD_BRANCH_ID,
@@ -37,7 +37,7 @@ import os.path
 import time
 
 # Test ZIP 239 behaviour before and after NU5.
-class Zip239Test(BitcoinTestFramework):
+class Zip239Test(ZcashTestFramework):
     def __init__(self):
         super().__init__()
         self.cache_behavior = 'sprout'

--- a/qa/rpc-tests/feature_zip244_blockcommitments.py
+++ b/qa/rpc-tests/feature_zip244_blockcommitments.py
@@ -5,7 +5,7 @@
 
 
 from test_framework.blocktools import derive_block_commitments_hash
-from test_framework.test_framework import BitcoinTestFramework
+from test_framework.test_framework import ZcashTestFramework
 from test_framework.util import (
     BLOSSOM_BRANCH_ID,
     CANOPY_BRANCH_ID,
@@ -21,7 +21,7 @@ from test_framework.util import (
 TERMINATOR = b'\x00' * 32
 
 # Verify block header field 'hashLightClientRoot' is set correctly for NU5 blocks.
-class AuthDataRootTest(BitcoinTestFramework):
+class AuthDataRootTest(ZcashTestFramework):
 
     def __init__(self):
         super().__init__()

--- a/qa/rpc-tests/finalorchardroot.py
+++ b/qa/rpc-tests/finalorchardroot.py
@@ -4,7 +4,7 @@
 # file COPYING or https://www.opensource.org/licenses/mit-license.php .
 
 
-from test_framework.test_framework import BitcoinTestFramework
+from test_framework.test_framework import ZcashTestFramework
 from test_framework.util import (
     NU5_BRANCH_ID,
     assert_equal,
@@ -25,7 +25,7 @@ NULL_FIELD = "0000000000000000000000000000000000000000000000000000000000000000"
 
 # Verify block header field 'hashFinalOrchardRoot' (returned in rpc as 'finalorchardroot')
 # is updated when Orchard transactions with outputs (commitments) are mined into a block.
-class FinalOrchardRootTest(BitcoinTestFramework):
+class FinalOrchardRootTest(ZcashTestFramework):
 
     def __init__(self):
         super().__init__()

--- a/qa/rpc-tests/finalsaplingroot.py
+++ b/qa/rpc-tests/finalsaplingroot.py
@@ -4,7 +4,7 @@
 # file COPYING or https://www.opensource.org/licenses/mit-license.php .
 
 
-from test_framework.test_framework import BitcoinTestFramework
+from test_framework.test_framework import ZcashTestFramework
 from test_framework.util import (
     NU5_BRANCH_ID,
     assert_equal,
@@ -25,7 +25,7 @@ NULL_FIELD = "0000000000000000000000000000000000000000000000000000000000000000"
 
 # Verify block header field 'hashFinalSaplingRoot' (returned in rpc as 'finalsaplingroot')
 # is updated when Sapling transactions with outputs (commitments) are mined into a block.
-class FinalSaplingRootTest(BitcoinTestFramework):
+class FinalSaplingRootTest(ZcashTestFramework):
 
     def __init__(self):
         super().__init__()

--- a/qa/rpc-tests/fix_block_commitments.py
+++ b/qa/rpc-tests/fix_block_commitments.py
@@ -3,7 +3,7 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://www.opensource.org/licenses/mit-license.php .
 
-from test_framework.test_framework import BitcoinTestFramework
+from test_framework.test_framework import ZcashTestFramework
 from test_framework.config import ZebraArgs
 from test_framework.util import (
     assert_true,
@@ -20,7 +20,7 @@ from test_framework.util import (
 #
 # Previous to the fix, the blockcommitments field was zero when both
 # Heartwood and NU5 activated in the same block.
-class BlockCommitmentsTest(BitcoinTestFramework):
+class BlockCommitmentsTest(ZcashTestFramework):
 
     def __init__(self):
         super().__init__()

--- a/qa/rpc-tests/forknotify.py
+++ b/qa/rpc-tests/forknotify.py
@@ -8,12 +8,12 @@
 # Test -alertnotify 
 #
 
-from test_framework.test_framework import BitcoinTestFramework
+from test_framework.test_framework import ZcashTestFramework
 from test_framework.util import start_node, connect_nodes
 
 import os
 
-class ForkNotifyTest(BitcoinTestFramework):
+class ForkNotifyTest(ZcashTestFramework):
 
     def __init__(self):
         super().__init__()

--- a/qa/rpc-tests/framework.py
+++ b/qa/rpc-tests/framework.py
@@ -3,7 +3,7 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://www.opensource.org/licenses/mit-license.php .
 
-from test_framework.test_framework import BitcoinTestFramework
+from test_framework.test_framework import ZcashTestFramework
 from test_framework.util import (
     assert_raises,
     connect_nodes,
@@ -11,7 +11,7 @@ from test_framework.util import (
     check_node_log,
 )
 
-class FrameworkTest (BitcoinTestFramework):
+class FrameworkTest (ZcashTestFramework):
 
     def __init__(self):
         super().__init__()

--- a/qa/rpc-tests/fundrawtransaction.py
+++ b/qa/rpc-tests/fundrawtransaction.py
@@ -4,16 +4,16 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://www.opensource.org/licenses/mit-license.php .
 
-from test_framework.test_framework import BitcoinTestFramework
+from test_framework.test_framework import ZcashTestFramework
 from test_framework.authproxy import JSONRPCException
 from test_framework.util import assert_equal, assert_greater_than, \
     start_nodes, connect_nodes_bi, stop_nodes, \
-    wait_bitcoinds
+    wait_nodes
 
 from decimal import Decimal
 
 # Create one-input, one-output, no-fee transaction:
-class RawTransactionsTest(BitcoinTestFramework):
+class RawTransactionsTest(ZcashTestFramework):
 
     def __init__(self):
         super().__init__()
@@ -451,7 +451,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         self.nodes[1].encryptwallet("test")
         self.nodes.pop(1)
         stop_nodes(self.nodes)
-        wait_bitcoinds()
+        wait_nodes()
 
         self.nodes = start_nodes(self.num_nodes, self.options.tmpdir, extra_args=[[
             '-allowdeprecated=getnewaddress',

--- a/qa/rpc-tests/getblocktemplate.py
+++ b/qa/rpc-tests/getblocktemplate.py
@@ -5,7 +5,7 @@
 
 from io import BytesIO
 
-from test_framework.test_framework import BitcoinTestFramework
+from test_framework.test_framework import ZcashTestFramework
 from test_framework.util import (
     assert_equal,
     CANOPY_BRANCH_ID,
@@ -27,7 +27,7 @@ from test_framework.zip317 import conventional_fee, ZIP_317_FEE
 
 from decimal import Decimal
 
-class GetBlockTemplateTest(BitcoinTestFramework):
+class GetBlockTemplateTest(ZcashTestFramework):
     '''
     Test getblocktemplate, ensure that a block created from its result
     can be submitted and accepted.

--- a/qa/rpc-tests/getblocktemplate_longpoll.py
+++ b/qa/rpc-tests/getblocktemplate_longpoll.py
@@ -4,7 +4,7 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://www.opensource.org/licenses/mit-license.php .
 
-from test_framework.test_framework import BitcoinTestFramework
+from test_framework.test_framework import ZcashTestFramework
 from test_framework.util import get_rpc_proxy, random_transaction
 
 from decimal import Decimal
@@ -45,7 +45,7 @@ class LongpollThread(threading.Thread):
     def run(self):
         self.node.getblocktemplate({'longpollid':self.longpollid})
 
-class GetBlockTemplateLPTest(BitcoinTestFramework):
+class GetBlockTemplateLPTest(ZcashTestFramework):
     '''
     Test longpolling with getblocktemplate.
     '''

--- a/qa/rpc-tests/getblocktemplate_proposals.py
+++ b/qa/rpc-tests/getblocktemplate_proposals.py
@@ -4,7 +4,7 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://www.opensource.org/licenses/mit-license.php .
 
-from test_framework.test_framework import BitcoinTestFramework
+from test_framework.test_framework import ZcashTestFramework
 from test_framework.authproxy import JSONRPCException
 
 from binascii import a2b_hex, b2a_hex
@@ -90,7 +90,7 @@ def assert_template(node, tmpl, txlist, expect):
     if rsp != expect:
         raise AssertionError('unexpected: %s' % (rsp,))
 
-class GetBlockTemplateProposalTest(BitcoinTestFramework):
+class GetBlockTemplateProposalTest(ZcashTestFramework):
     '''
     Test block proposals with getblocktemplate.
     '''

--- a/qa/rpc-tests/getchaintips.py
+++ b/qa/rpc-tests/getchaintips.py
@@ -9,10 +9,10 @@
 # This gives us two tips, verify that it works.
 
 
-from test_framework.test_framework import BitcoinTestFramework
+from test_framework.test_framework import ZcashTestFramework
 from test_framework.util import assert_equal
 
-class GetChainTipsTest (BitcoinTestFramework):
+class GetChainTipsTest (ZcashTestFramework):
 
     def run_test (self):
 

--- a/qa/rpc-tests/getmininginfo.py
+++ b/qa/rpc-tests/getmininginfo.py
@@ -3,10 +3,10 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://www.opensource.org/licenses/mit-license.php .
 
-from test_framework.test_framework import BitcoinTestFramework
+from test_framework.test_framework import ZcashTestFramework
 
 
-class GetMiningInfoTest(BitcoinTestFramework):
+class GetMiningInfoTest(ZcashTestFramework):
     '''
     Test getmininginfo.
     '''

--- a/qa/rpc-tests/getrawtransaction_insight.py
+++ b/qa/rpc-tests/getrawtransaction_insight.py
@@ -8,16 +8,16 @@
 # RPC for the Insight Explorer by the new spentindex
 #
 
-from test_framework.test_framework import BitcoinTestFramework
+from test_framework.test_framework import ZcashTestFramework
 
 from test_framework.util import assert_equal
 from test_framework.util import start_nodes, stop_nodes, connect_nodes
-from test_framework.util import wait_bitcoinds
+from test_framework.util import wait_nodes
 
 from test_framework.mininode import COIN
 
 
-class GetrawtransactionTest(BitcoinTestFramework):
+class GetrawtransactionTest(ZcashTestFramework):
 
     def __init__(self):
         super().__init__()
@@ -81,7 +81,7 @@ class GetrawtransactionTest(BitcoinTestFramework):
 
         # Restart all nodes to ensure index files are saved to disk and recovered
         stop_nodes(self.nodes)
-        wait_bitcoinds()
+        wait_nodes()
         self.setup_network()
 
         # Check new fields added to getrawtransaction

--- a/qa/rpc-tests/getrawtransaction_sidechain.py
+++ b/qa/rpc-tests/getrawtransaction_sidechain.py
@@ -7,12 +7,12 @@
 # Test getrawtransaction on side chains
 #
 
-from test_framework.test_framework import BitcoinTestFramework
+from test_framework.test_framework import ZcashTestFramework
 from test_framework.util import assert_equal
 from test_framework.proxy import JSONRPCException
 
 
-class GetRawTransactionSideChainTest(BitcoinTestFramework):
+class GetRawTransactionSideChainTest(ZcashTestFramework):
     def __init__(self):
         super().__init__()
         self.num_nodes = 1

--- a/qa/rpc-tests/hardforkdetection.py
+++ b/qa/rpc-tests/hardforkdetection.py
@@ -4,13 +4,13 @@
 # Test hard fork detection
 #
 
-from test_framework.test_framework import BitcoinTestFramework
+from test_framework.test_framework import ZcashTestFramework
 from test_framework.authproxy import JSONRPCException
 from test_framework.util import assert_equal, start_node
 
 import os
 
-class HardForkDetectionTest(BitcoinTestFramework):
+class HardForkDetectionTest(ZcashTestFramework):
 
     alert_filename = None  # Set by setup_network
 

--- a/qa/rpc-tests/httpbasics.py
+++ b/qa/rpc-tests/httpbasics.py
@@ -8,13 +8,13 @@
 # Test rpc http basics
 #
 
-from test_framework.test_framework import BitcoinTestFramework
+from test_framework.test_framework import ZcashTestFramework
 from test_framework.util import assert_equal, str_to_b64str
 
 import http.client
 import urllib.parse
 
-class HTTPBasicsTest (BitcoinTestFramework):
+class HTTPBasicsTest (ZcashTestFramework):
     def __init__(self):
         super().__init__()
         self.num_nodes = 3

--- a/qa/rpc-tests/indexer.py
+++ b/qa/rpc-tests/indexer.py
@@ -3,11 +3,11 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://www.opensource.org/licenses/mit-license.php .
 
-from test_framework.test_framework import BitcoinTestFramework
+from test_framework.test_framework import ZcashTestFramework
 from test_framework.util import assert_equal
 
 # Test that we can call the indexer RPCs.
-class IndexerTest (BitcoinTestFramework):
+class IndexerTest (ZcashTestFramework):
 
     def __init__(self):
         super().__init__()

--- a/qa/rpc-tests/invalidateblock.py
+++ b/qa/rpc-tests/invalidateblock.py
@@ -8,13 +8,13 @@
 # Test InvalidateBlock code
 #
 
-from test_framework.test_framework import BitcoinTestFramework
+from test_framework.test_framework import ZcashTestFramework
 from test_framework.util import start_node, \
     connect_nodes_bi, sync_blocks
 
 import time
 
-class InvalidateTest(BitcoinTestFramework):
+class InvalidateTest(ZcashTestFramework):
     def __init__(self):
         super().__init__()
         self.cache_behavior = 'clean'

--- a/qa/rpc-tests/key_import_export.py
+++ b/qa/rpc-tests/key_import_export.py
@@ -5,7 +5,7 @@
 
 from decimal import Decimal
 from functools import reduce
-from test_framework.test_framework import BitcoinTestFramework
+from test_framework.test_framework import ZcashTestFramework
 from test_framework.util import assert_equal, assert_greater_than, start_nodes, connect_nodes_bi
 
 import logging
@@ -14,7 +14,7 @@ import sys
 logging.basicConfig(format='%(levelname)s: %(message)s', level=logging.INFO, stream=sys.stdout)
 
 
-class KeyImportExportTest (BitcoinTestFramework):
+class KeyImportExportTest (ZcashTestFramework):
 
     def __init__(self):
         super().__init__()

--- a/qa/rpc-tests/keypool.py
+++ b/qa/rpc-tests/keypool.py
@@ -7,9 +7,9 @@
 # Exercise the wallet keypool, and interaction with wallet encryption/locking
 
 from test_framework.authproxy import JSONRPCException
-from test_framework.test_framework import BitcoinTestFramework
+from test_framework.test_framework import ZcashTestFramework
 from test_framework.util import assert_equal, \
-    start_nodes, start_node, bitcoind_processes
+    start_nodes, start_node, node_processes
 
 def check_array_result(object_array, to_match, expected):
     """
@@ -32,13 +32,13 @@ def check_array_result(object_array, to_match, expected):
     if num_matched == 0:
         raise AssertionError("No objects matched %s"%(str(to_match)))
 
-class KeyPoolTest(BitcoinTestFramework):
+class KeyPoolTest(ZcashTestFramework):
 
     def run_test(self):
         nodes = self.nodes
         # Encrypt wallet and wait to terminate
         nodes[0].encryptwallet('test')
-        bitcoind_processes[0].wait()
+        node_processes[0].wait()
         # Restart node 0
         nodes[0] = start_node(0, self.options.tmpdir, extra_args=[
             '-allowdeprecated=getnewaddress',

--- a/qa/rpc-tests/listtransactions.py
+++ b/qa/rpc-tests/listtransactions.py
@@ -6,7 +6,7 @@
 
 # Exercise the listtransactions API
 
-from test_framework.test_framework import BitcoinTestFramework
+from test_framework.test_framework import ZcashTestFramework
 from test_framework.util import assert_equal, start_nodes
 
 from decimal import Decimal
@@ -39,7 +39,7 @@ def check_array_result(object_array, to_match, expected):
     if num_matched == 0:
         raise AssertionError("No objects matched %s"%(str(to_match)))
 
-class ListTransactionsTest(BitcoinTestFramework):
+class ListTransactionsTest(ZcashTestFramework):
 
     def setup_nodes(self):
         return start_nodes(self.num_nodes, self.options.tmpdir, extra_args=[[

--- a/qa/rpc-tests/maxblocksinflight.py
+++ b/qa/rpc-tests/maxblocksinflight.py
@@ -6,7 +6,7 @@
 
 from test_framework.mininode import NodeConn, NodeConnCB, NetworkThread, \
     EarlyDisconnectError, CInv, msg_inv, mininode_lock
-from test_framework.test_framework import BitcoinTestFramework
+from test_framework.test_framework import ZcashTestFramework
 from test_framework.util import ZCASHD_BINARY, start_nodes, p2p_port
 
 import os
@@ -80,7 +80,7 @@ class TestManager(NodeConnCB):
         self.connection.disconnect_node()
 
 
-class MaxBlocksInFlightTest(BitcoinTestFramework):
+class MaxBlocksInFlightTest(ZcashTestFramework):
     def add_options(self, parser):
         parser.add_option("--testbinary", dest="testbinary",
                           default=os.getenv("ZCASHD", ZCASHD_BINARY),

--- a/qa/rpc-tests/maxuploadtarget.py
+++ b/qa/rpc-tests/maxuploadtarget.py
@@ -10,7 +10,7 @@ from test_framework.mininode import ( \
         BLOSSOM_PROTO_VERSION
         )
 
-from test_framework.test_framework import BitcoinTestFramework
+from test_framework.test_framework import ZcashTestFramework
 from test_framework.util import ( \
         ZCASHD_BINARY, assert_equal, initialize_chain_clean, \
         start_node, stop_node, \
@@ -93,7 +93,7 @@ class TestNode(NodeConnCB):
         self.ping_counter += 1
         return success
 
-class MaxUploadTest(BitcoinTestFramework):
+class MaxUploadTest(ZcashTestFramework):
     def __init__(self):
         self.utxo = []
 

--- a/qa/rpc-tests/mempool_limit.py
+++ b/qa/rpc-tests/mempool_limit.py
@@ -4,7 +4,7 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://www.opensource.org/licenses/mit-license.php .
 
-from test_framework.test_framework import BitcoinTestFramework
+from test_framework.test_framework import ZcashTestFramework
 from test_framework.util import (
     assert_equal,
     get_coinbase_address,
@@ -24,7 +24,7 @@ BASE_ARGS = [
 ]
 
 # Test wallet behaviour with Sapling addresses
-class MempoolLimit(BitcoinTestFramework):
+class MempoolLimit(ZcashTestFramework):
     def setup_nodes(self):
         extra_args = [
             BASE_ARGS + ['-mempooltxcostlimit=20000'], # 2 transactions at min cost

--- a/qa/rpc-tests/mempool_nu_activation.py
+++ b/qa/rpc-tests/mempool_nu_activation.py
@@ -3,7 +3,7 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://www.opensource.org/licenses/mit-license.php .
 
-from test_framework.test_framework import BitcoinTestFramework
+from test_framework.test_framework import ZcashTestFramework
 from test_framework.util import (
     BLOSSOM_BRANCH_ID,
     CANOPY_BRANCH_ID,
@@ -20,7 +20,7 @@ from test_framework.zip317 import conventional_fee
 from decimal import Decimal
 
 # Test mempool behaviour around network upgrade activation
-class MempoolUpgradeActivationTest(BitcoinTestFramework):
+class MempoolUpgradeActivationTest(ZcashTestFramework):
 
     alert_filename = None  # Set by setup_network
 

--- a/qa/rpc-tests/mempool_packages.py
+++ b/qa/rpc-tests/mempool_packages.py
@@ -6,7 +6,7 @@
 
 # Test descendant package tracking code
 
-from test_framework.test_framework import BitcoinTestFramework
+from test_framework.test_framework import ZcashTestFramework
 from test_framework.util import (
     ROUND_DOWN,
     Decimal,
@@ -23,7 +23,7 @@ from test_framework.zip317 import conventional_fee
 def satoshi_round(amount):
     return  Decimal(amount).quantize(Decimal('0.00000001'), rounding=ROUND_DOWN)
 
-class MempoolPackagesTest(BitcoinTestFramework):
+class MempoolPackagesTest(ZcashTestFramework):
     limitdescendantcount = 120
 
     def setup_network(self):

--- a/qa/rpc-tests/mempool_reorg.py
+++ b/qa/rpc-tests/mempool_reorg.py
@@ -11,14 +11,14 @@
 
 from decimal import Decimal
 
-from test_framework.test_framework import BitcoinTestFramework
+from test_framework.test_framework import ZcashTestFramework
 from test_framework.authproxy import JSONRPCException
 from test_framework.util import assert_equal, assert_raises, start_node, connect_nodes
 from test_framework.zip317 import conventional_fee
 
 
 # Create one-input, one-output, no-fee transaction:
-class MempoolCoinbaseTest(BitcoinTestFramework):
+class MempoolCoinbaseTest(ZcashTestFramework):
     def __init__(self):
         super().__init__()
         self.num_nodes = 2

--- a/qa/rpc-tests/mempool_resurrect_test.py
+++ b/qa/rpc-tests/mempool_resurrect_test.py
@@ -9,7 +9,7 @@
 # the blockchain is re-organized.
 #
 
-from test_framework.test_framework import BitcoinTestFramework
+from test_framework.test_framework import ZcashTestFramework
 from test_framework.util import assert_equal, start_node
 from test_framework.zip317 import conventional_fee
 
@@ -17,7 +17,7 @@ from decimal import Decimal
 
 
 # Create one-input, one-output, no-fee transaction:
-class MempoolCoinbaseTest(BitcoinTestFramework):
+class MempoolCoinbaseTest(ZcashTestFramework):
 
     def __init__(self):
         super().__init__()

--- a/qa/rpc-tests/mempool_spendcoinbase.py
+++ b/qa/rpc-tests/mempool_spendcoinbase.py
@@ -16,7 +16,7 @@
 
 from decimal import Decimal
 
-from test_framework.test_framework import BitcoinTestFramework
+from test_framework.test_framework import ZcashTestFramework
 from test_framework.authproxy import JSONRPCException
 from test_framework.util import assert_equal, assert_greater_than, assert_raises, \
     start_node
@@ -24,7 +24,7 @@ from test_framework.zip317 import conventional_fee
 
 
 # Create one-input, one-output, no-fee transaction:
-class MempoolSpendCoinbaseTest(BitcoinTestFramework):
+class MempoolSpendCoinbaseTest(ZcashTestFramework):
 
     def __init__(self):
         super().__init__()

--- a/qa/rpc-tests/mempool_tx_expiry.py
+++ b/qa/rpc-tests/mempool_tx_expiry.py
@@ -8,7 +8,7 @@
 #
 
 from test_framework.authproxy import JSONRPCException
-from test_framework.test_framework import BitcoinTestFramework
+from test_framework.test_framework import ZcashTestFramework
 from test_framework.util import assert_equal, \
     connect_nodes_bi, sync_blocks, start_nodes, \
     wait_and_assert_operationid_status
@@ -19,7 +19,7 @@ from decimal import Decimal
 TX_EXPIRING_SOON_THRESHOLD = 3
 TX_EXPIRY_DELTA = 10
 
-class MempoolTxExpiryTest(BitcoinTestFramework):
+class MempoolTxExpiryTest(ZcashTestFramework):
 
     def setup_nodes(self):
         return start_nodes(self.num_nodes, self.options.tmpdir, extra_args=[[

--- a/qa/rpc-tests/mergetoaddress_mixednotes.py
+++ b/qa/rpc-tests/mergetoaddress_mixednotes.py
@@ -4,14 +4,14 @@
 # file COPYING or https://www.opensource.org/licenses/mit-license.php .
 
 from decimal import Decimal
-from test_framework.test_framework import BitcoinTestFramework
+from test_framework.test_framework import ZcashTestFramework
 from test_framework.util import assert_equal, get_coinbase_address, \
     start_nodes, wait_and_assert_operationid_status
 from test_framework.zip317 import conventional_fee
 from mergetoaddress_helper import assert_mergetoaddress_exception
 
 
-class MergeToAddressMixedNotes(BitcoinTestFramework):
+class MergeToAddressMixedNotes(ZcashTestFramework):
     def __init__(self):
         super().__init__()
         self.cache_behavior = 'sprout'

--- a/qa/rpc-tests/mergetoaddress_sapling.py
+++ b/qa/rpc-tests/mergetoaddress_sapling.py
@@ -3,13 +3,13 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://www.opensource.org/licenses/mit-license.php .
 
-from test_framework.test_framework import BitcoinTestFramework
+from test_framework.test_framework import ZcashTestFramework
 from mergetoaddress_helper import MergeToAddressHelper
 
 def get_new_address(test, node):
     return test.nodes[node].z_getnewaddress('sapling')
 
-class MergeToAddressSapling (BitcoinTestFramework):
+class MergeToAddressSapling (ZcashTestFramework):
     helper = MergeToAddressHelper(get_new_address, 'ANY_SAPLING')
 
     def setup_chain(self):

--- a/qa/rpc-tests/mergetoaddress_ua_nu5.py
+++ b/qa/rpc-tests/mergetoaddress_ua_nu5.py
@@ -3,7 +3,7 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://www.opensource.org/licenses/mit-license.php .
 
-from test_framework.test_framework import BitcoinTestFramework
+from test_framework.test_framework import ZcashTestFramework
 from test_framework.util import NU5_BRANCH_ID, nuparams
 from mergetoaddress_helper import MergeToAddressHelper
 
@@ -13,7 +13,7 @@ def get_new_address(test, node):
     #       Orchard, so exclude it from the UA for now.
     return test.nodes[node].z_getaddressforaccount(account, ['p2pkh', 'sapling'])['address']
 
-class MergeToAddressUANU5 (BitcoinTestFramework):
+class MergeToAddressUANU5 (ZcashTestFramework):
     # TODO: Until we can merge from Orchard, we just use 'ANY_SAPLING' as the wildcard here, since
     # we don’t have an `'ANY_ORCHARD'` yet and `'ANY_SPROUT'` isn’t compatible with Orchard.
     helper = MergeToAddressHelper(get_new_address, 'ANY_SAPLING')

--- a/qa/rpc-tests/mergetoaddress_ua_sapling.py
+++ b/qa/rpc-tests/mergetoaddress_ua_sapling.py
@@ -3,7 +3,7 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://www.opensource.org/licenses/mit-license.php .
 
-from test_framework.test_framework import BitcoinTestFramework
+from test_framework.test_framework import ZcashTestFramework
 from test_framework.util import NU5_BRANCH_ID, nuparams
 from mergetoaddress_helper import MergeToAddressHelper
 
@@ -11,7 +11,7 @@ def get_new_address(test, node):
     account = test.nodes[node].z_getnewaccount()['account']
     return test.nodes[node].z_getaddressforaccount(account)['address']
 
-class MergeToAddressUASapling (BitcoinTestFramework):
+class MergeToAddressUASapling (ZcashTestFramework):
     helper = MergeToAddressHelper(get_new_address, 'ANY_SAPLING')
 
     def setup_chain(self):

--- a/qa/rpc-tests/merkle_blocks.py
+++ b/qa/rpc-tests/merkle_blocks.py
@@ -9,13 +9,13 @@
 #
 
 import string
-from test_framework.test_framework import BitcoinTestFramework
+from test_framework.test_framework import ZcashTestFramework
 from test_framework.authproxy import JSONRPCException
 from test_framework.util import assert_equal, assert_raises_message, start_node, connect_nodes
 from test_framework.zip317 import conventional_fee
 
 
-class MerkleBlockTest(BitcoinTestFramework):
+class MerkleBlockTest(ZcashTestFramework):
 
     def __init__(self):
         super().__init__()

--- a/qa/rpc-tests/mining_shielded_coinbase.py
+++ b/qa/rpc-tests/mining_shielded_coinbase.py
@@ -5,7 +5,7 @@
 
 from decimal import Decimal
 from test_framework.authproxy import JSONRPCException
-from test_framework.test_framework import BitcoinTestFramework
+from test_framework.test_framework import ZcashTestFramework
 from test_framework.mininode import COIN, nuparams
 from test_framework.util import (
     BLOSSOM_BRANCH_ID,
@@ -14,7 +14,7 @@ from test_framework.util import (
     NU5_BRANCH_ID,
     assert_equal,
     assert_raises,
-    bitcoind_processes,
+    node_processes,
     connect_nodes,
     start_node,
     wait_and_assert_operationid_status,
@@ -22,7 +22,7 @@ from test_framework.util import (
 )
 from test_framework.zip317 import conventional_fee
 
-class ShieldCoinbaseTest (BitcoinTestFramework):
+class ShieldCoinbaseTest (ZcashTestFramework):
 
     def __init__(self):
         super().__init__()
@@ -56,7 +56,7 @@ class ShieldCoinbaseTest (BitcoinTestFramework):
         node1_zaddr = self.nodes[1].z_getnewaddress('sapling')
 
         self.nodes[1].stop()
-        bitcoind_processes[1].wait()
+        node_processes[1].wait()
         self.nodes[1] = self.start_node_with(1, [
             "-mineraddress=%s" % node1_zaddr,
         ])
@@ -137,7 +137,7 @@ class ShieldCoinbaseTest (BitcoinTestFramework):
 
         # Set node 1's miner address to the UA
         self.nodes[1].stop()
-        bitcoind_processes[1].wait()
+        node_processes[1].wait()
         self.nodes[1] = self.start_node_with(1, [
             "-mineraddress=%s" % node1_ua,
         ])

--- a/qa/rpc-tests/multi_rpc.py
+++ b/qa/rpc-tests/multi_rpc.py
@@ -8,14 +8,14 @@
 # Test multiple rpc user config option rpcauth
 #
 
-from test_framework.test_framework import BitcoinTestFramework
+from test_framework.test_framework import ZcashTestFramework
 from test_framework.util import str_to_b64str, assert_equal
 
 import os
 import http.client
 import urllib.parse
 
-class HTTPBasicsTest (BitcoinTestFramework):
+class HTTPBasicsTest (ZcashTestFramework):
 
     def __init__(self):
         super().__init__()

--- a/qa/rpc-tests/nodehandling.py
+++ b/qa/rpc-tests/nodehandling.py
@@ -8,14 +8,14 @@
 # Test node handling
 #
 
-from test_framework.test_framework import BitcoinTestFramework
+from test_framework.test_framework import ZcashTestFramework
 from test_framework.util import assert_equal, connect_nodes_bi, p2p_port, \
     start_node, stop_node
 
 import time
 import urllib.parse
 
-class NodeHandlingTest (BitcoinTestFramework):
+class NodeHandlingTest (ZcashTestFramework):
 
     def run_test(self):
         ###########################

--- a/qa/rpc-tests/nuparams.py
+++ b/qa/rpc-tests/nuparams.py
@@ -4,7 +4,7 @@
 # file COPYING or https://www.opensource.org/licenses/mit-license.php .
 
 from test_framework.config import ZebraArgs
-from test_framework.test_framework import BitcoinTestFramework
+from test_framework.test_framework import ZcashTestFramework
 from test_framework.util import (
     assert_equal,
     start_nodes,
@@ -20,7 +20,7 @@ from test_framework.util import (
 from decimal import Decimal
 
 
-class NuparamsTest(BitcoinTestFramework):
+class NuparamsTest(ZcashTestFramework):
     '''
     Test that unspecified network upgrades are activated automatically;
     this is really more of a test of the test framework.

--- a/qa/rpc-tests/orchard_reorg.py
+++ b/qa/rpc-tests/orchard_reorg.py
@@ -7,7 +7,7 @@
 # Test the effect of reorgs on the Orchard commitment tree.
 #
 
-from test_framework.test_framework import BitcoinTestFramework
+from test_framework.test_framework import ZcashTestFramework
 from test_framework.util import (
     BLOSSOM_BRANCH_ID,
     HEARTWOOD_BRANCH_ID,
@@ -23,7 +23,7 @@ from test_framework.zip317 import ZIP_317_FEE
 
 from finalsaplingroot import ORCHARD_TREE_EMPTY_ROOT
 
-class OrchardReorgTest(BitcoinTestFramework):
+class OrchardReorgTest(ZcashTestFramework):
     def __init__(self):
         super().__init__()
         self.num_nodes = 4

--- a/qa/rpc-tests/p2p-acceptblock.py
+++ b/qa/rpc-tests/p2p-acceptblock.py
@@ -7,7 +7,7 @@
 from test_framework.mininode import CBlockHeader, CInv, NodeConn, NodeConnCB, \
     NetworkThread, msg_block, msg_headers, msg_inv, msg_ping, msg_pong, \
     mininode_lock
-from test_framework.test_framework import BitcoinTestFramework
+from test_framework.test_framework import ZcashTestFramework
 from test_framework.util import assert_equal, \
     start_node, p2p_port, ZCASHD_BINARY
 from test_framework.blocktools import create_block, create_coinbase
@@ -112,7 +112,7 @@ class TestNode(NodeConnCB):
         return received_pong
 
 
-class AcceptBlockTest(BitcoinTestFramework):
+class AcceptBlockTest(ZcashTestFramework):
     def add_options(self, parser):
         parser.add_option("--testbinary", dest="testbinary",
                           default=os.getenv("ZCASHD", ZCASHD_BINARY),

--- a/qa/rpc-tests/p2p_node_bloom.py
+++ b/qa/rpc-tests/p2p_node_bloom.py
@@ -5,7 +5,7 @@
 
 from test_framework.mininode import NodeConn, NodeConnCB, NetworkThread, \
     msg_filteradd, msg_filterclear, mininode_lock, SAPLING_PROTO_VERSION
-from test_framework.test_framework import BitcoinTestFramework
+from test_framework.test_framework import ZcashTestFramework
 from test_framework.util import initialize_chain_clean, start_nodes, \
     p2p_port, assert_equal
 
@@ -43,7 +43,7 @@ class TestNode(NodeConnCB):
         conn.rejectMessage = message
 
 
-class NodeBloomTest(BitcoinTestFramework):
+class NodeBloomTest(ZcashTestFramework):
 
     def setup_chain(self):
         print("Initializing test directory "+self.options.tmpdir)

--- a/qa/rpc-tests/p2p_nu_peer_management.py
+++ b/qa/rpc-tests/p2p_nu_peer_management.py
@@ -12,7 +12,7 @@ from test_framework.mininode import (
     OVERWINTER_PROTO_VERSION,
     SAPLING_PROTO_VERSION,
 )
-from test_framework.test_framework import BitcoinTestFramework
+from test_framework.test_framework import ZcashTestFramework
 from test_framework.util import initialize_chain_clean, start_nodes, \
     p2p_port, assert_equal
 
@@ -49,7 +49,7 @@ class TestManager(NodeConnCB):
         conn.rejectMessage = message
 
 
-class NUPeerManagementTest(BitcoinTestFramework):
+class NUPeerManagementTest(ZcashTestFramework):
 
     def setup_chain(self):
         print("Initializing test directory "+self.options.tmpdir)

--- a/qa/rpc-tests/p2p_txexpiringsoon.py
+++ b/qa/rpc-tests/p2p_txexpiringsoon.py
@@ -8,7 +8,7 @@ from decimal import Decimal
 from test_framework.authproxy import JSONRPCException
 from test_framework.mininode import NodeConn, NetworkThread, CInv, \
     msg_mempool, msg_getdata, msg_tx, mininode_lock, SAPLING_PROTO_VERSION
-from test_framework.test_framework import BitcoinTestFramework
+from test_framework.test_framework import ZcashTestFramework
 from test_framework.util import assert_equal, connect_nodes_bi, fail, \
     p2p_port, start_nodes, sync_blocks, sync_mempools
 from test_framework.zip317 import conventional_fee
@@ -16,7 +16,7 @@ from test_framework.zip317 import conventional_fee
 from tx_expiry_helper import TestNode, create_transaction
 
 
-class TxExpiringSoonTest(BitcoinTestFramework):
+class TxExpiringSoonTest(ZcashTestFramework):
 
     def __init__(self):
         super().__init__()

--- a/qa/rpc-tests/p2p_txexpiry_dos.py
+++ b/qa/rpc-tests/p2p_txexpiry_dos.py
@@ -5,14 +5,14 @@
 
 from test_framework.mininode import NodeConn, NetworkThread, \
     msg_tx, SAPLING_PROTO_VERSION
-from test_framework.test_framework import BitcoinTestFramework
+from test_framework.test_framework import ZcashTestFramework
 from test_framework.util import start_nodes, p2p_port, assert_equal
 from tx_expiry_helper import TestNode, create_transaction
 
 import time
 
 
-class TxExpiryDoSTest(BitcoinTestFramework):
+class TxExpiryDoSTest(ZcashTestFramework):
 
     def __init__(self):
         super().__init__()

--- a/qa/rpc-tests/post_heartwood_rollback.py
+++ b/qa/rpc-tests/post_heartwood_rollback.py
@@ -7,10 +7,10 @@
 Test rollbacks on post-Heartwood chains.
 '''
 
-from test_framework.test_framework import BitcoinTestFramework
+from test_framework.test_framework import ZcashTestFramework
 from test_framework.util import (
     assert_equal,
-    bitcoind_processes,
+    node_processes,
     connect_nodes_bi,
     nuparams,
     start_node,
@@ -26,7 +26,7 @@ import time
 HAS_CANOPY = [nuparams(BLOSSOM_BRANCH_ID, 205), nuparams(HEARTWOOD_BRANCH_ID, 210), nuparams(CANOPY_BRANCH_ID, 220), '-nurejectoldversions=false']
 NO_CANOPY  = [nuparams(BLOSSOM_BRANCH_ID, 205), nuparams(HEARTWOOD_BRANCH_ID, 210), '-nurejectoldversions=false']
 
-class PostHeartwoodRollbackTest (BitcoinTestFramework):
+class PostHeartwoodRollbackTest (ZcashTestFramework):
 
     def setup_nodes(self):
         return start_nodes(self.num_nodes, self.options.tmpdir, extra_args=[
@@ -70,11 +70,11 @@ class PostHeartwoodRollbackTest (BitcoinTestFramework):
         # Upgrade node 2 and 3 to Canopy
         print("Upgrading nodes 2 and 3 to Canopy")
         self.nodes[2].stop()
-        bitcoind_processes[2].wait()
+        node_processes[2].wait()
         self.nodes[2] = start_node(2, self.options.tmpdir, extra_args=HAS_CANOPY)
 
         self.nodes[3].stop()
-        bitcoind_processes[3].wait()
+        node_processes[3].wait()
         self.nodes[3] = start_node(3, self.options.tmpdir, extra_args=HAS_CANOPY)
 
         # for i in range (0,3,2):

--- a/qa/rpc-tests/prioritisetransaction.py
+++ b/qa/rpc-tests/prioritisetransaction.py
@@ -3,7 +3,7 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://www.opensource.org/licenses/mit-license.php .
 
-from test_framework.test_framework import BitcoinTestFramework
+from test_framework.test_framework import ZcashTestFramework
 from test_framework.authproxy import JSONRPCException
 from test_framework.util import assert_equal, assert_raises_message, start_nodes, \
     sync_blocks, sync_mempools, wait_and_assert_operationid_status
@@ -14,7 +14,7 @@ import time
 from decimal import Decimal
 
 
-class PrioritiseTransactionTest(BitcoinTestFramework):
+class PrioritiseTransactionTest(ZcashTestFramework):
     def __init__(self):
         super().__init__()
         self.cache_behavior = 'clean'

--- a/qa/rpc-tests/proxy_test.py
+++ b/qa/rpc-tests/proxy_test.py
@@ -8,7 +8,7 @@ import socket
 import os
 
 from test_framework.socks5 import Socks5Configuration, Socks5Command, Socks5Server, AddressType
-from test_framework.test_framework import BitcoinTestFramework
+from test_framework.test_framework import ZcashTestFramework
 from test_framework.util import assert_equal, start_nodes
 from test_framework.netutil import test_ipv6_local
 '''
@@ -35,7 +35,7 @@ addnode connect to onion
 addnode connect to generic DNS name
 '''
 
-class ProxyTest(BitcoinTestFramework):        
+class ProxyTest(ZcashTestFramework):        
     def __init__(self):
         super().__init__()
 

--- a/qa/rpc-tests/pruning.py
+++ b/qa/rpc-tests/pruning.py
@@ -12,7 +12,7 @@
 # This test takes 30 mins or more (up to 2 hours)
 # ********
 
-from test_framework.test_framework import BitcoinTestFramework
+from test_framework.test_framework import ZcashTestFramework
 from test_framework.authproxy import JSONRPCException
 from test_framework.util import start_node, \
     connect_nodes, stop_node, sync_blocks
@@ -23,7 +23,7 @@ import time
 def calc_usage(blockdir):
     return sum(os.path.getsize(blockdir+f) for f in os.listdir(blockdir) if os.path.isfile(blockdir+f)) / (1024. * 1024.)
 
-class PruneTest(BitcoinTestFramework):
+class PruneTest(ZcashTestFramework):
 
     def __init__(self):
         super().__init__()

--- a/qa/rpc-tests/rawtransactions.py
+++ b/qa/rpc-tests/rawtransactions.py
@@ -9,7 +9,7 @@
 # that spend (directly or indirectly) coinbase transactions.
 #
 
-from test_framework.test_framework import BitcoinTestFramework
+from test_framework.test_framework import ZcashTestFramework
 from test_framework.authproxy import JSONRPCException
 from test_framework.util import assert_equal, \
     start_nodes, connect_nodes_bi, assert_raises
@@ -17,7 +17,7 @@ from test_framework.util import assert_equal, \
 from decimal import Decimal
 
 # Create one-input, one-output, no-fee transaction:
-class RawTransactionsTest(BitcoinTestFramework):
+class RawTransactionsTest(ZcashTestFramework):
 
     def __init__(self):
         super().__init__()

--- a/qa/rpc-tests/receivedby.py
+++ b/qa/rpc-tests/receivedby.py
@@ -6,7 +6,7 @@
 
 # Exercise the listreceivedbyaddress API
 
-from test_framework.test_framework import BitcoinTestFramework
+from test_framework.test_framework import ZcashTestFramework
 from test_framework.util import assert_equal
 
 from decimal import Decimal
@@ -52,7 +52,7 @@ def check_array_result(object_array, to_match, expected, should_not_find = False
     if num_matched > 0 and should_not_find == True:
         raise AssertionError("Objects was matched %s"%(str(to_match)))
 
-class ReceivedByTest(BitcoinTestFramework):
+class ReceivedByTest(ZcashTestFramework):
 
     def run_test(self):
         '''

--- a/qa/rpc-tests/regtest_signrawtransaction.py
+++ b/qa/rpc-tests/regtest_signrawtransaction.py
@@ -3,14 +3,14 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://www.opensource.org/licenses/mit-license.php .
 
-from test_framework.test_framework import BitcoinTestFramework
+from test_framework.test_framework import ZcashTestFramework
 from test_framework.util import (
     start_nodes,
     wait_and_assert_operationid_status,
 )
 from test_framework.zip317 import ZIP_317_FEE
 
-class RegtestSignrawtransactionTest (BitcoinTestFramework):
+class RegtestSignrawtransactionTest (ZcashTestFramework):
 
     def setup_nodes(self):
         return start_nodes(self.num_nodes, self.options.tmpdir, extra_args=[[

--- a/qa/rpc-tests/remove_sprout_shielding.py
+++ b/qa/rpc-tests/remove_sprout_shielding.py
@@ -5,7 +5,7 @@
 
 from decimal import Decimal
 from test_framework.authproxy import JSONRPCException
-from test_framework.test_framework import BitcoinTestFramework
+from test_framework.test_framework import ZcashTestFramework
 from test_framework.util import (
     assert_equal,
     assert_raises_message,
@@ -33,7 +33,7 @@ HAS_CANOPY = [
     '-allowdeprecated=z_getbalance',
 ]
 
-class RemoveSproutShieldingTest (BitcoinTestFramework):
+class RemoveSproutShieldingTest (ZcashTestFramework):
     def __init__(self):
         super().__init__()
         self.num_nodes = 4

--- a/qa/rpc-tests/reorg_limit.py
+++ b/qa/rpc-tests/reorg_limit.py
@@ -7,7 +7,7 @@
 # Test reorg limit
 #
 
-from test_framework.test_framework import BitcoinTestFramework
+from test_framework.test_framework import ZcashTestFramework
 from test_framework.util import (
     check_node,
     connect_nodes_bi,
@@ -29,7 +29,7 @@ def check_stopped(i, timeout=10):
             break
     return stopped
 
-class ReorgLimitTest(BitcoinTestFramework):
+class ReorgLimitTest(ZcashTestFramework):
 
     def setup_nodes(self):
         self.log_stderr = tempfile.SpooledTemporaryFile(max_size=2**16)

--- a/qa/rpc-tests/rest.py
+++ b/qa/rpc-tests/rest.py
@@ -8,7 +8,7 @@
 # Test REST interface
 #
 
-from test_framework.test_framework import BitcoinTestFramework
+from test_framework.test_framework import ZcashTestFramework
 from test_framework.util import assert_equal, assert_greater_than, \
     hex_str_to_bytes, start_nodes, connect_nodes_bi
 
@@ -48,7 +48,7 @@ def http_post_call(host, port, path, requestdata = '', response_object = 0):
 
     return conn.getresponse().read()
 
-class RESTTest (BitcoinTestFramework):
+class RESTTest (ZcashTestFramework):
     FORMAT_SEPARATOR = "."
 
     def __init__(self):

--- a/qa/rpc-tests/rewind_index.py
+++ b/qa/rpc-tests/rewind_index.py
@@ -3,9 +3,9 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://www.opensource.org/licenses/mit-license.php .
 
-from test_framework.test_framework import BitcoinTestFramework
+from test_framework.test_framework import ZcashTestFramework
 from test_framework.util import assert_equal, \
-    start_nodes, start_node, connect_nodes_bi, bitcoind_processes, \
+    start_nodes, start_node, connect_nodes_bi, node_processes, \
     nuparams, sync_blocks, OVERWINTER_BRANCH_ID, SAPLING_BRANCH_ID
 
 import time
@@ -13,7 +13,7 @@ import time
 FAKE_SPROUT = [nuparams(OVERWINTER_BRANCH_ID, 210), nuparams(SAPLING_BRANCH_ID, 220)]
 FAKE_OVERWINTER = [nuparams(OVERWINTER_BRANCH_ID, 10), nuparams(SAPLING_BRANCH_ID, 220)]
 
-class RewindBlockIndexTest (BitcoinTestFramework):
+class RewindBlockIndexTest (ZcashTestFramework):
 
     def __init__(self):
         super().__init__()
@@ -57,7 +57,7 @@ class RewindBlockIndexTest (BitcoinTestFramework):
         # Restart node 0 using Sprout instead of Overwinter
         print("Switching node 0 from Overwinter to Sprout")
         self.nodes[0].stop()
-        bitcoind_processes[0].wait()
+        node_processes[0].wait()
         self.nodes[0] = start_node(0, self.options.tmpdir, extra_args=FAKE_SPROUT)
         connect_nodes_bi(self.nodes,0,1)
         connect_nodes_bi(self.nodes,1,2)
@@ -74,7 +74,7 @@ class RewindBlockIndexTest (BitcoinTestFramework):
         # Restart node 0 using Overwinter instead of Sprout
         print("Switching node 0 from Sprout to Overwinter")
         self.nodes[0].stop()
-        bitcoind_processes[0].wait()
+        node_processes[0].wait()
         self.nodes[0] = start_node(0, self.options.tmpdir, extra_args=FAKE_OVERWINTER)
         connect_nodes_bi(self.nodes,0,1)
         connect_nodes_bi(self.nodes,1,2)

--- a/qa/rpc-tests/rpcbind_test.py
+++ b/qa/rpc-tests/rpcbind_test.py
@@ -9,23 +9,23 @@
 # Dependency: python-bitcoinrpc
 
 from test_framework.authproxy import JSONRPCException
-from test_framework.test_framework import BitcoinTestFramework
+from test_framework.test_framework import ZcashTestFramework
 from test_framework.util import (
     assert_equal,
-    bitcoind_processes,
+    node_processes,
     get_rpc_proxy,
     rpc_port,
     rpc_url,
     start_nodes,
     stop_nodes,
-    wait_bitcoinds,
+    wait_nodes,
 )
 from test_framework.netutil import addr_to_hex, get_bind_addrs, all_interfaces
 
 import sys
 
 
-class RPCBindTest(BitcoinTestFramework):
+class RPCBindTest(ZcashTestFramework):
 
     def __init__(self):
         super().__init__()
@@ -51,11 +51,11 @@ class RPCBindTest(BitcoinTestFramework):
         binds = ['-rpcbind='+addr for addr in addresses]
         self.nodes = start_nodes(self.num_nodes, self.options.tmpdir, [base_args + binds], connect_to)
         try:
-            pid = bitcoind_processes[0].pid
+            pid = node_processes[0].pid
             assert_equal(set(get_bind_addrs(pid)), set(expected))
         finally:
             stop_nodes(self.nodes)
-            wait_bitcoinds()
+            wait_nodes()
 
     def run_allowip_test(self, allow_ips, rpchost, rpcport):
         '''
@@ -71,7 +71,7 @@ class RPCBindTest(BitcoinTestFramework):
         finally:
             node = None # make sure connection will be garbage collected and closed
             stop_nodes(self.nodes)
-            wait_bitcoinds()
+            wait_nodes()
 
     def run_test(self):
         # due to OS-specific network stats queries, this test works only on Linux

--- a/qa/rpc-tests/sapling_rewind_check.py
+++ b/qa/rpc-tests/sapling_rewind_check.py
@@ -26,11 +26,11 @@ length computation (40b5d5e3ea4b602c34c4efaba0b9f6171dddfef5) corrects the issue
 
 """
 
-from test_framework.test_framework import BitcoinTestFramework
+from test_framework.test_framework import ZcashTestFramework
 from test_framework.util import (assert_equal, assert_true,
     assert_start_raises_init_error,
     start_nodes, start_node, connect_nodes_bi,
-    bitcoind_processes,
+    node_processes,
     nuparams, OVERWINTER_BRANCH_ID, SAPLING_BRANCH_ID)
 
 import logging
@@ -41,7 +41,7 @@ logging.basicConfig(format='%(levelname)s: %(message)s', level=logging.INFO, str
 HAS_SAPLING = [nuparams(OVERWINTER_BRANCH_ID, 10), nuparams(SAPLING_BRANCH_ID, 15)]
 NO_SAPLING = [nuparams(OVERWINTER_BRANCH_ID, 10), nuparams(SAPLING_BRANCH_ID, 150)]
 
-class SaplingRewindTest(BitcoinTestFramework):
+class SaplingRewindTest(ZcashTestFramework):
     def __init__(self):
         super().__init__()
         self.num_nodes = 3
@@ -91,7 +91,7 @@ class SaplingRewindTest(BitcoinTestFramework):
         # Stop the overwinter node to ensure state is flushed to disk.
         logging.info("Shutting down lagging node...")
         self.nodes[2].stop()
-        bitcoind_processes[2].wait()
+        node_processes[2].wait()
         
         # Restart the nodes, reconnect, and sync the network. This succeeds if "-reindex" is passed.
         logging.info("Reconnecting the network...")

--- a/qa/rpc-tests/shorter_block_times.py
+++ b/qa/rpc-tests/shorter_block_times.py
@@ -4,7 +4,7 @@
 # file COPYING or https://www.opensource.org/licenses/mit-license.php .
 
 from decimal import Decimal
-from test_framework.test_framework import BitcoinTestFramework
+from test_framework.test_framework import ZcashTestFramework
 from test_framework.util import (
     BLOSSOM_BRANCH_ID,
     assert_equal,
@@ -16,7 +16,7 @@ from test_framework.util import (
 from test_framework.zip317 import conventional_fee
 
 
-class ShorterBlockTimes(BitcoinTestFramework):
+class ShorterBlockTimes(ZcashTestFramework):
     def __init__(self):
         super().__init__()
         self.num_nodes = 4

--- a/qa/rpc-tests/show_help.py
+++ b/qa/rpc-tests/show_help.py
@@ -8,7 +8,7 @@
 # Test --help
 #
 
-from test_framework.test_framework import BitcoinTestFramework
+from test_framework.test_framework import ZcashTestFramework
 from test_framework.util import assert_equal, zebrad_binary
 
 from difflib import SequenceMatcher, unified_diff
@@ -606,7 +606,7 @@ Compatibility options:
 
 """
 
-class ShowHelpTest(BitcoinTestFramework):
+class ShowHelpTest(ZcashTestFramework):
 
     def setup_network(self):
         self.nodes = []

--- a/qa/rpc-tests/signrawtransaction_offline.py
+++ b/qa/rpc-tests/signrawtransaction_offline.py
@@ -3,7 +3,7 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://www.opensource.org/licenses/mit-license.php .
 
-from test_framework.test_framework import BitcoinTestFramework
+from test_framework.test_framework import ZcashTestFramework
 from test_framework.util import (
     BLOSSOM_BRANCH_ID,
     assert_equal,
@@ -18,7 +18,7 @@ from test_framework.authproxy import JSONRPCException
 from decimal import Decimal
 
 
-class SignOfflineTest (BitcoinTestFramework):
+class SignOfflineTest (ZcashTestFramework):
     # Setup Methods
     def setup_chain(self):
         print("Initializing test directory " + self.options.tmpdir)

--- a/qa/rpc-tests/signrawtransactions.py
+++ b/qa/rpc-tests/signrawtransactions.py
@@ -4,11 +4,11 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://www.opensource.org/licenses/mit-license.php .
 
-from test_framework.test_framework import BitcoinTestFramework
+from test_framework.test_framework import ZcashTestFramework
 from test_framework.util import assert_equal
 
 
-class SignRawTransactionsTest(BitcoinTestFramework):
+class SignRawTransactionsTest(ZcashTestFramework):
     """Tests transaction signing via RPC command "signrawtransaction"."""
 
     def __init__(self):

--- a/qa/rpc-tests/spentindex.py
+++ b/qa/rpc-tests/spentindex.py
@@ -5,7 +5,7 @@
 #
 # Test spentindex generation and fetching for insightexplorer
 
-from test_framework.test_framework import BitcoinTestFramework
+from test_framework.test_framework import ZcashTestFramework
 from test_framework.authproxy import JSONRPCException
 
 from test_framework.util import (
@@ -14,14 +14,14 @@ from test_framework.util import (
     start_nodes,
     stop_nodes,
     connect_nodes,
-    wait_bitcoinds,
+    wait_nodes,
     fail,
 )
 
 from test_framework.mininode import COIN
 
 
-class SpentIndexTest(BitcoinTestFramework):
+class SpentIndexTest(ZcashTestFramework):
 
     def setup_chain(self):
         print("Initializing test directory "+self.options.tmpdir)
@@ -77,7 +77,7 @@ class SpentIndexTest(BitcoinTestFramework):
 
         # Restart all nodes to ensure index files are saved to disk and recovered
         stop_nodes(self.nodes)
-        wait_bitcoinds()
+        wait_nodes()
         self.setup_network()
 
         # Check new fields added to getrawtransaction

--- a/qa/rpc-tests/sprout_sapling_migration.py
+++ b/qa/rpc-tests/sprout_sapling_migration.py
@@ -4,7 +4,7 @@
 # file COPYING or https://www.opensource.org/licenses/mit-license.php .
 
 from decimal import Decimal
-from test_framework.test_framework import BitcoinTestFramework
+from test_framework.test_framework import ZcashTestFramework
 from test_framework.util import assert_equal, assert_true, \
     start_nodes, \
     wait_and_assert_operationid_status_result
@@ -49,7 +49,7 @@ def check_migration_status(node, destination_address, migration_state):
     assert_equal(num_migration_txids, len(status['migration_txids']), "Num migration txids; status=%r" % (status,))
 
 
-class SproutSaplingMigration(BitcoinTestFramework):
+class SproutSaplingMigration(ZcashTestFramework):
     def __init__(self):
         super().__init__()
         self.num_nodes = 4

--- a/qa/rpc-tests/test_framework/test_framework.py
+++ b/qa/rpc-tests/test_framework/test_framework.py
@@ -30,7 +30,7 @@ from .util import (
     stop_nodes,
     stop_wallets,
     stop_zainos,
-    wait_bitcoinds,
+    wait_nodes,
     wait_zainods,
     wait_zallets,
     enable_coverage,
@@ -39,7 +39,7 @@ from .util import (
 )
 
 
-class BitcoinTestFramework(object):
+class ZcashTestFramework(object):
 
     def __init__(self):
         self.num_nodes = 4
@@ -125,7 +125,7 @@ class BitcoinTestFramework(object):
         stop_zainos(self.zainos)
         wait_zainods()
         stop_nodes(self.nodes)
-        wait_bitcoinds()
+        wait_nodes()
         self.setup_network(True)
 
     def sync_all(self, do_mempool_sync = True):
@@ -156,18 +156,18 @@ class BitcoinTestFramework(object):
         stop_zainos(self.zainos)
         wait_zainods()
         stop_nodes(self.nodes)
-        wait_bitcoinds()
+        wait_nodes()
         self.setup_network(False, False)
 
     def main(self):
 
         parser = optparse.OptionParser(usage="%prog [options]")
         parser.add_option("--nocleanup", dest="nocleanup", default=False, action="store_true",
-                          help="Leave bitcoinds and test.* datadir on exit or error")
+                          help="Leave nodes and test.* datadir on exit or error")
         parser.add_option("--noshutdown", dest="noshutdown", default=False, action="store_true",
-                          help="Don't stop bitcoinds after the test execution")
+                          help="Don't stop nodes after the test execution")
         parser.add_option("--srcdir", dest="srcdir", default="../../src",
-                          help="Source directory containing bitcoind/bitcoin-cli (default: %default)")
+                          help="Source directory containing the node binaries (default: %default)")
         parser.add_option("--cachedir", dest="cachedir", default=os.path.normpath(os.path.dirname(os.path.realpath(__file__))+"/../../cache"),
                           help="Directory for caching pregenerated datadirs")
         parser.add_option("--tmpdir", dest="tmpdir", default=tempfile.mkdtemp(prefix="test"),
@@ -228,7 +228,7 @@ class BitcoinTestFramework(object):
 
             print("Stopping nodes")
             stop_nodes(self.nodes)
-            wait_bitcoinds()
+            wait_nodes()
         else:
             print("Note: zebrads, zainods, and zallets were not stopped and may still be running")
 
@@ -244,13 +244,13 @@ class BitcoinTestFramework(object):
             sys.exit(1)
 
 
-# Test framework for doing p2p comparison testing, which sets up some bitcoind
+# Test framework for doing p2p comparison testing, which sets up some nodes
 # binaries:
 # 1 binary: test binary
 # 2 binaries: 1 test binary, 1 ref binary
 # n>2 binaries: 1 test binary, n-1 ref binaries
 
-class ComparisonTestFramework(BitcoinTestFramework):
+class ComparisonTestFramework(ZcashTestFramework):
 
     def __init__(self):
         super().__init__()

--- a/qa/rpc-tests/test_framework/util.py
+++ b/qa/rpc-tests/test_framework/util.py
@@ -191,7 +191,7 @@ def sync_mempools(rpc_connections, wait=0.5, timeout=60):
         timeout -= wait
     return True
 
-bitcoind_processes = {}
+node_processes = {}
 
 def initialize_datadir(dirname, n, clock_offset=0):
     datadir = node_dir(dirname, n)
@@ -263,8 +263,8 @@ PROC_START_TIMEOUT = int(os.getenv("PROC_START_TIMEOUT", "120"))
 
 def wait_for_zebrad_start(process, url, i):
     '''
-    Wait for bitcoind to start. This means that RPC is accessible and fully initialized.
-    Raise an exception if bitcoind exits during initialization, or fails to become
+    Wait for node to start. This means that RPC is accessible and fully initialized.
+    Raise an exception if node exits during initialization, or fails to become
     ready within PROC_START_TIMEOUT seconds.
     '''
     deadline = time.time() + PROC_START_TIMEOUT
@@ -344,7 +344,7 @@ def initialize_chain(test_dir, num_nodes, cachedir, cache_behavior='current'):
 
             miner_addresses[i] = miner_address
 
-        # Create cache directories, run bitcoinds:
+        # Create cache directories, run nodes:
         block_time = int(time.time()) - (200 * PRE_BLOSSOM_BLOCK_TARGET_SPACING)
         for i in range(MAX_NODES):
             datadir = initialize_datadir(cachedir, i)
@@ -354,10 +354,10 @@ def initialize_chain(test_dir, num_nodes, cachedir, cache_behavior='current'):
             ))
             args = [ zebrad_binary(), "-c="+config, "start" ]
 
-            bitcoind_processes[i] = subprocess.Popen(args)
+            node_processes[i] = subprocess.Popen(args)
             if os.getenv("PYTHON_DEBUG", ""):
                 print("initialize_chain: %s started, waiting for RPC to come up" % (zebrad_binary(),))
-            wait_for_zebrad_start(bitcoind_processes[i], rpc_url(i), i)
+            wait_for_zebrad_start(node_processes[i], rpc_url(i), i)
             if os.getenv("PYTHON_DEBUG", ""):
                 print("initialize_chain: RPC successfully started")
 
@@ -397,14 +397,14 @@ def initialize_chain(test_dir, num_nodes, cachedir, cache_behavior='current'):
                 # - https://github.com/ZcashFoundation/zebra/issues/10329
                 # - https://github.com/ZcashFoundation/zebra/issues/10332
                 stop_nodes(rpcs)
-                wait_bitcoinds()
+                wait_nodes()
                 for i in range(MAX_NODES):
                     config = zebrad_config(node_dir(cachedir, i))
                     args = [ zebrad_binary(), "-c="+config, "start" ]
-                    bitcoind_processes[i] = subprocess.Popen(args)
+                    node_processes[i] = subprocess.Popen(args)
                     if os.getenv("PYTHON_DEBUG", ""):
                         print("initialize_chain: %s started, waiting for RPC to come up" % (zebrad_binary(),))
-                    wait_for_zebrad_start(bitcoind_processes[i], rpc_url(i), i)
+                    wait_for_zebrad_start(node_processes[i], rpc_url(i), i)
                     if os.getenv("PYTHON_DEBUG", ""):
                         print("initialize_chain: RPC successfully started")
                 for i in range(MAX_NODES):
@@ -445,7 +445,7 @@ def initialize_chain(test_dir, num_nodes, cachedir, cache_behavior='current'):
         stop_wallets(wallets)
         wait_zallets()
         stop_nodes(rpcs)
-        wait_bitcoinds()
+        wait_nodes()
         for i in range(MAX_NODES):
             # record the system time at which the cache was regenerated
             with open(node_file(cachedir, i, 'cache_config.json'), "w", encoding="utf8") as cache_conf_file:
@@ -619,7 +619,7 @@ def _rpchost_to_args(rpchost):
 
 def start_node(i, dirname, extra_args=None, rpchost=None, timewait=None, binary=None, stderr=None):
     """
-    Start a bitcoind and return RPC connection to it
+    Start a node and return RPC connection to it
     """
     datadir = node_dir(dirname, i)
     if binary is None:
@@ -627,13 +627,13 @@ def start_node(i, dirname, extra_args=None, rpchost=None, timewait=None, binary=
     config = update_zebrad_conf(datadir, rpc_port(i), p2p_port(i), indexer_rpc_port(i), extra_args)
     args = [ binary, "-c="+config, "start" ]
 
-    bitcoind_processes[i] = subprocess.Popen(args, stderr=stderr)
+    node_processes[i] = subprocess.Popen(args, stderr=stderr)
     if os.getenv("PYTHON_DEBUG", ""):
-        print("start_node: bitcoind started, waiting for RPC to come up")
+        print("start_node: node started, waiting for RPC to come up")
     url = rpc_url(i, rpchost)
-    wait_for_zebrad_start(bitcoind_processes[i], url, i)
+    wait_for_zebrad_start(node_processes[i], url, i)
     if os.getenv("PYTHON_DEBUG", ""):
-        print("start_node: RPC successfully started for node {} with pid {}".format(i, bitcoind_processes[i].pid))
+        print("start_node: RPC successfully started for node {} with pid {}".format(i, node_processes[i].pid))
     proxy = get_rpc_proxy(url, i, timeout=timewait)
 
     if COVERAGE_DIR:
@@ -662,7 +662,7 @@ def assert_start_raises_init_error(i, dirname, extra_args=None, expected_msg=Non
 
 def start_nodes(num_nodes, dirname, extra_args=None, rpchost=None, binary=None):
     """
-    Start multiple bitcoinds, return RPC connections to them
+    Start multiple nodes, return RPC connections to them
     """
     if extra_args is None: extra_args = [ None for _ in range(num_nodes) ]
     if binary is None: binary = [ None for _ in range(num_nodes) ]
@@ -685,16 +685,16 @@ def wallet_dir(dirname, n_wallet):
     return os.path.join(dirname, "wallet"+str(n_wallet))
 
 def check_node(i):
-    bitcoind_processes[i].poll()
-    return bitcoind_processes[i].returncode
+    node_processes[i].poll()
+    return node_processes[i].returncode
 
 def stop_node(node, i):
     try:
         node.stop()
     except http.client.CannotSendRequest as e:
         print("WARN: Unable to stop node: " + repr(e))
-    bitcoind_processes[i].wait()
-    del bitcoind_processes[i]
+    node_processes[i].wait()
+    del node_processes[i]
 
 def stop_nodes(nodes):
     for node in nodes:
@@ -725,11 +725,11 @@ def wait_or_kill(proc):
         proc.kill()
         proc.wait()
 
-def wait_bitcoinds():
-    # Wait for all bitcoinds to cleanly exit
-    for bitcoind in list(bitcoind_processes.values()):
-        wait_or_kill(bitcoind)
-    bitcoind_processes.clear()
+def wait_nodes():
+    # Wait for all nodes to cleanly exit
+    for node in list(node_processes.values()):
+        wait_or_kill(node)
+    node_processes.clear()
 
 def connect_nodes(from_connection, node_num):
     ip_port = "127.0.0.1:"+str(p2p_port(node_num))
@@ -910,7 +910,7 @@ def check_node_log(self, node_number, line_to_check, stop_node = True):
     print("Checking node " + str(node_number) + " logs")
     if stop_node:
         self.nodes[node_number].stop()
-        bitcoind_processes[node_number].wait()
+        node_processes[node_number].wait()
     logpath = self.options.tmpdir + "/node" + str(node_number) + "/regtest/debug.log"
     with open(logpath, "r", encoding="utf8") as myfile:
         logdata = myfile.readlines()

--- a/qa/rpc-tests/threeofthreerestore.py
+++ b/qa/rpc-tests/threeofthreerestore.py
@@ -3,10 +3,10 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://www.opensource.org/licenses/mit-license.php .
 
-from test_framework.test_framework import BitcoinTestFramework
+from test_framework.test_framework import ZcashTestFramework
 from test_framework.util import start_nodes, connect_nodes_bi 
 
-class ThreeOfThreeRestoreTest(BitcoinTestFramework):
+class ThreeOfThreeRestoreTest(ZcashTestFramework):
 
     def __init__(self):
         super().__init__()

--- a/qa/rpc-tests/timestampindex.py
+++ b/qa/rpc-tests/timestampindex.py
@@ -7,7 +7,7 @@
 
 import time
 
-from test_framework.test_framework import BitcoinTestFramework
+from test_framework.test_framework import ZcashTestFramework
 
 from test_framework.util import (
     assert_equal,
@@ -15,11 +15,11 @@ from test_framework.util import (
     start_nodes,
     stop_nodes,
     connect_nodes,
-    wait_bitcoinds,
+    wait_nodes,
 )
 
 
-class TimestampIndexTest(BitcoinTestFramework):
+class TimestampIndexTest(ZcashTestFramework):
 
     def setup_chain(self):
         print("Initializing test directory "+self.options.tmpdir)
@@ -57,7 +57,7 @@ class TimestampIndexTest(BitcoinTestFramework):
 
         # Restart all nodes to ensure indices are saved to disk and recovered
         stop_nodes(self.nodes)
-        wait_bitcoinds()
+        wait_nodes()
         self.setup_network()
 
         # generating multiple blocks within the same second should

--- a/qa/rpc-tests/turnstile.py
+++ b/qa/rpc-tests/turnstile.py
@@ -26,7 +26,7 @@
 # 7. Verify zcashd rejected the block
 #
 
-from test_framework.test_framework import BitcoinTestFramework
+from test_framework.test_framework import ZcashTestFramework
 from test_framework.util import (
     assert_equal,
     fail,
@@ -35,7 +35,7 @@ from test_framework.util import (
     sync_blocks, sync_mempools,
     connect_nodes_bi,
     wait_and_assert_operationid_status,
-    bitcoind_processes,
+    node_processes,
     check_node_log
 )
 from test_framework.zip317 import conventional_fee, ZIP_317_FEE
@@ -49,7 +49,7 @@ BASE_ARGS = [
 TURNSTILE_ARGS = ['-experimentalfeatures',
                   '-developersetpoolsizezero']
 
-class TurnstileTest (BitcoinTestFramework):
+class TurnstileTest (ZcashTestFramework):
 
     def __init__(self):
         super().__init__()
@@ -83,7 +83,7 @@ class TurnstileTest (BitcoinTestFramework):
     # Helper method to stop and restart a single node with extra args and sync to the network
     def restart_and_sync_node(self, index, args=[]):
         self.nodes[index].stop()
-        bitcoind_processes[index].wait()
+        node_processes[index].wait()
         self.start_and_sync_node(index, args)
 
     def run_test(self):

--- a/qa/rpc-tests/txn_doublespend.py
+++ b/qa/rpc-tests/txn_doublespend.py
@@ -8,7 +8,7 @@
 # Test proper accounting with malleable transactions
 #
 
-from test_framework.test_framework import BitcoinTestFramework
+from test_framework.test_framework import ZcashTestFramework
 from test_framework.util import (
     assert_equal,
     connect_nodes,
@@ -19,7 +19,7 @@ from test_framework.util import (
 from test_framework.zip317 import conventional_fee
 
 
-class TxnMallTest(BitcoinTestFramework):
+class TxnMallTest(ZcashTestFramework):
 
     def add_options(self, parser):
         parser.add_option("--mineblock", dest="mine_block", default=False, action="store_true",

--- a/qa/rpc-tests/upgrade_golden.py
+++ b/qa/rpc-tests/upgrade_golden.py
@@ -4,10 +4,10 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://www.opensource.org/licenses/mit-license.php .
 
-from test_framework.test_framework import BitcoinTestFramework
+from test_framework.test_framework import ZcashTestFramework
 from test_framework.util import (
     initialize_chain_clean, start_nodes, start_node,
-    bitcoind_processes, tarfile_extractall,
+    node_processes, tarfile_extractall,
 )
 from test_framework.util import (
     nuparams,
@@ -41,7 +41,7 @@ class Upgrade():
         self.tgz_path = p
         self.extra_args = a
 
-class UpgradeGoldenTest(BitcoinTestFramework):
+class UpgradeGoldenTest(ZcashTestFramework):
     def setup_chain(self):
         self.upgrades = [ Upgrade(35, os.path.dirname(os.path.realpath(__file__))+"/golden/blossom.tar.gz", HAS_BLOSSOM)
                         , Upgrade(45, os.path.dirname(os.path.realpath(__file__))+"/golden/heartwood.tar.gz", HAS_HEARTWOOD)
@@ -68,7 +68,7 @@ class UpgradeGoldenTest(BitcoinTestFramework):
         # Generate past the upgrade activation height.
         self.nodes[0].generate(to_height)
         self.nodes[0].stop()
-        bitcoind_processes[0].wait()
+        node_processes[0].wait()
 
         node_path = self.options.tmpdir + "/node0/regtest"
         os.remove(node_path + "/peers.dat")
@@ -89,7 +89,7 @@ class UpgradeGoldenTest(BitcoinTestFramework):
             if os.path.isfile(upgrade.tgz_path):
                 # shut down the node so we can replace its data dir(s)
                 self.nodes[i].stop()
-                bitcoind_processes[i].wait()
+                node_processes[i].wait()
 
                 regtest_path = self.options.tmpdir+"/node"+ str(i)+"/regtest"
                 shutil.rmtree(regtest_path)

--- a/qa/rpc-tests/wallet.py
+++ b/qa/rpc-tests/wallet.py
@@ -7,11 +7,11 @@
 #from decimal import Decimal
 import time
 
-from test_framework.test_framework import BitcoinTestFramework
+from test_framework.test_framework import ZcashTestFramework
 from test_framework.util import assert_equal, assert_true
 
 # Test that we can create a wallet and use an address from it to mine blocks.
-class WalletTest (BitcoinTestFramework):
+class WalletTest (ZcashTestFramework):
 
     def __init__(self):
         super().__init__()

--- a/qa/rpc-tests/wallet_1941.py
+++ b/qa/rpc-tests/wallet_1941.py
@@ -5,10 +5,10 @@
 
 # This is a regression test for #1941.
 
-from test_framework.test_framework import BitcoinTestFramework
+from test_framework.test_framework import ZcashTestFramework
 from test_framework.util import assert_equal, initialize_chain_clean, \
     initialize_datadir, start_nodes, start_node, connect_nodes_bi, \
-    bitcoind_processes, wait_and_assert_operationid_status, \
+    node_processes, wait_and_assert_operationid_status, \
     get_coinbase_address
 from test_framework.zip317 import conventional_fee
 
@@ -16,7 +16,7 @@ from decimal import Decimal
 
 starttime = 1388534400
 
-class Wallet1941RegressionTest (BitcoinTestFramework):
+class Wallet1941RegressionTest (ZcashTestFramework):
 
     def setup_chain(self):
         print("Initializing test directory "+self.options.tmpdir)
@@ -49,7 +49,7 @@ class Wallet1941RegressionTest (BitcoinTestFramework):
 
     def restart_second_node(self, extra_args=[]):
         self.nodes[1].stop()
-        bitcoind_processes[1].wait()
+        node_processes[1].wait()
         self.nodes[1] = start_node(1, self.options.tmpdir, extra_args=[
             '-regtestshieldcoinbase',
             '-debug=zrpc',

--- a/qa/rpc-tests/wallet_accounts.py
+++ b/qa/rpc-tests/wallet_accounts.py
@@ -5,7 +5,7 @@
 
 from test_framework.authproxy import JSONRPCException
 from test_framework.mininode import COIN
-from test_framework.test_framework import BitcoinTestFramework
+from test_framework.test_framework import ZcashTestFramework
 from test_framework.util import (
     NU5_BRANCH_ID,
     assert_equal,
@@ -21,7 +21,7 @@ from test_framework.zip317 import conventional_fee
 from decimal import Decimal
 
 # Test wallet accounts behaviour
-class WalletAccountsTest(BitcoinTestFramework):
+class WalletAccountsTest(ZcashTestFramework):
     def setup_nodes(self):
         return start_nodes(self.num_nodes, self.options.tmpdir, extra_args=[[
             nuparams(NU5_BRANCH_ID, 210),

--- a/qa/rpc-tests/wallet_addresses.py
+++ b/qa/rpc-tests/wallet_addresses.py
@@ -3,19 +3,19 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://www.opensource.org/licenses/mit-license.php .
 
-from test_framework.test_framework import BitcoinTestFramework
+from test_framework.test_framework import ZcashTestFramework
 from test_framework.util import (
     assert_equal,
     connect_nodes_bi,
     start_nodes,
     stop_nodes,
-    wait_bitcoinds,
+    wait_nodes,
     NU5_BRANCH_ID,
 )
 from test_framework.mininode import nuparams
 
 # Test wallet address behaviour across network upgrades
-class WalletAddressesTest(BitcoinTestFramework):
+class WalletAddressesTest(ZcashTestFramework):
     def __init__(self):
         super().__init__()
         # need 2 nodes to import addresses
@@ -127,7 +127,7 @@ class WalletAddressesTest(BitcoinTestFramework):
         # stop the nodes & restart to ensure that the imported address
         # still shows up in listaddresses output
         stop_nodes(self.nodes)
-        wait_bitcoinds()
+        wait_nodes()
         self.setup_network()
 
         listed_addresses = self.list_addresses(1, ['imported', 'mnemonic_seed'])

--- a/qa/rpc-tests/wallet_anchorfork.py
+++ b/qa/rpc-tests/wallet_anchorfork.py
@@ -3,16 +3,16 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://www.opensource.org/licenses/mit-license.php .
 
-from test_framework.test_framework import BitcoinTestFramework
+from test_framework.test_framework import ZcashTestFramework
 from test_framework.util import assert_equal, initialize_chain_clean, \
     start_nodes, stop_nodes, connect_nodes_bi, \
-    wait_and_assert_operationid_status, wait_bitcoinds, get_coinbase_address, \
+    wait_and_assert_operationid_status, wait_nodes, get_coinbase_address, \
     sync_blocks, sync_mempools
 from test_framework.zip317 import conventional_fee
 
 from decimal import Decimal
 
-class WalletAnchorForkTest (BitcoinTestFramework):
+class WalletAnchorForkTest (ZcashTestFramework):
 
     def setup_chain(self):
         print("Initializing test directory "+self.options.tmpdir)
@@ -65,7 +65,7 @@ class WalletAnchorForkTest (BitcoinTestFramework):
 
         # Stop nodes.
         stop_nodes(self.nodes)
-        wait_bitcoinds()
+        wait_nodes()
 
         # Relaunch nodes and partition network into two:
         # A: node 0
@@ -103,7 +103,7 @@ class WalletAnchorForkTest (BitcoinTestFramework):
 
         # Shut down all nodes so any in-memory state is saved to disk
         stop_nodes(self.nodes)
-        wait_bitcoinds()
+        wait_nodes()
 
         # Relaunch nodes and reconnect the entire network
         self.nodes = start_nodes(3, self.options.tmpdir, extra_args=[['-regtestshieldcoinbase', '-debug=zrpc']] * 3 )

--- a/qa/rpc-tests/wallet_broadcast.py
+++ b/qa/rpc-tests/wallet_broadcast.py
@@ -3,8 +3,8 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://www.opensource.org/licenses/mit-license.php .
 
-from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import assert_equal, connect_nodes_bi, start_nodes, stop_nodes, sync_blocks, wait_bitcoinds
+from test_framework.test_framework import ZcashTestFramework
+from test_framework.util import assert_equal, connect_nodes_bi, start_nodes, stop_nodes, sync_blocks, wait_nodes
 from decimal import Decimal
 
 BASE_ARGS = [
@@ -12,11 +12,11 @@ BASE_ARGS = [
 ]
 
 # Test wallet address behaviour across network upgrades
-class WalletBroadcastTest(BitcoinTestFramework):
+class WalletBroadcastTest(ZcashTestFramework):
     def run_test(self):
         #do some -walletbroadcast tests
         stop_nodes(self.nodes)
-        wait_bitcoinds()
+        wait_nodes()
         self.nodes = start_nodes(3, self.options.tmpdir, [BASE_ARGS + ["-walletbroadcast=0"]] * 3)
         connect_nodes_bi(self.nodes,0,1)
         connect_nodes_bi(self.nodes,1,2)
@@ -45,7 +45,7 @@ class WalletBroadcastTest(BitcoinTestFramework):
 
         #restart the nodes with -walletbroadcast=1
         stop_nodes(self.nodes)
-        wait_bitcoinds()
+        wait_nodes()
         self.nodes = start_nodes(3, self.options.tmpdir, [BASE_ARGS] * 3)
         connect_nodes_bi(self.nodes,0,1)
         connect_nodes_bi(self.nodes,1,2)

--- a/qa/rpc-tests/wallet_changeaddresses.py
+++ b/qa/rpc-tests/wallet_changeaddresses.py
@@ -3,7 +3,7 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://www.opensource.org/licenses/mit-license.php .
 
-from test_framework.test_framework import BitcoinTestFramework
+from test_framework.test_framework import ZcashTestFramework
 from test_framework.util import (
     SAPLING_BRANCH_ID,
     connect_nodes_bi,
@@ -18,7 +18,7 @@ from test_framework.zip317 import conventional_fee, ZIP_317_FEE
 from decimal import Decimal
 
 # Test wallet change address behaviour
-class WalletChangeAddressesTest(BitcoinTestFramework):
+class WalletChangeAddressesTest(ZcashTestFramework):
 
     def setup_chain(self):
         print("Initializing test directory " + self.options.tmpdir)

--- a/qa/rpc-tests/wallet_changeindicator.py
+++ b/qa/rpc-tests/wallet_changeindicator.py
@@ -3,7 +3,7 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://www.opensource.org/licenses/mit-license.php .
 
-from test_framework.test_framework import BitcoinTestFramework
+from test_framework.test_framework import ZcashTestFramework
 from test_framework.util import (
     assert_equal,
     assert_false,
@@ -15,7 +15,7 @@ from test_framework.zip317 import conventional_fee
 
 from decimal import Decimal
 
-class WalletChangeIndicatorTest (BitcoinTestFramework):
+class WalletChangeIndicatorTest (ZcashTestFramework):
     # Helper Methods
     def generate_and_sync(self):
         self.sync_all()

--- a/qa/rpc-tests/wallet_db_flush.py
+++ b/qa/rpc-tests/wallet_db_flush.py
@@ -6,16 +6,16 @@
 # This test reproduces https://github.com/zcash/zcash/issues/4301
 # It takes an hour to run!
 
-from test_framework.test_framework import BitcoinTestFramework
+from test_framework.test_framework import ZcashTestFramework
 from test_framework.util import (
     assert_equal,
-    bitcoind_processes,
+    node_processes,
     initialize_chain_clean,
     start_node,
 )
 import time
 
-class WalletDBFlush (BitcoinTestFramework):
+class WalletDBFlush (ZcashTestFramework):
 
     def setup_chain(self):
         print("Initializing test directory "+self.options.tmpdir)
@@ -46,7 +46,7 @@ class WalletDBFlush (BitcoinTestFramework):
         self.nodes[0].generate(2)
 
         self.nodes[0].stop()
-        bitcoind_processes[0].wait()
+        node_processes[0].wait()
 
         print("Start mining to address ", zaddr)
         self.nodes[0] = self.start_node_with(0, [
@@ -55,7 +55,7 @@ class WalletDBFlush (BitcoinTestFramework):
         self.nodes[0].generate(1)
         self.sync_all()
         self.nodes[0].stop()
-        bitcoind_processes[0].wait()
+        node_processes[0].wait()
 
         # If you replace main.cpp:3129 DATABASE_WRITE_INTERVAL with
         # 60 (seconds), then sleeptime here can be 80, and this test
@@ -71,7 +71,7 @@ class WalletDBFlush (BitcoinTestFramework):
         self.nodes[0].generate(1)
         self.sync_all()
         self.nodes[0].stop()
-        bitcoind_processes[0].wait()
+        node_processes[0].wait()
 
         print("Restart, generate, expect assert in CopyPreviousWitnesses")
         self.nodes[0] = self.start_node_with(0, [

--- a/qa/rpc-tests/wallet_deprecation.py
+++ b/qa/rpc-tests/wallet_deprecation.py
@@ -3,12 +3,12 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://www.opensource.org/licenses/mit-license.php .
 
-from test_framework.test_framework import BitcoinTestFramework
+from test_framework.test_framework import ZcashTestFramework
 from test_framework.util import (
     assert_true,
     start_nodes,
     stop_nodes,
-    wait_bitcoinds,
+    wait_nodes,
 )
 from test_framework.authproxy import JSONRPCException
 
@@ -25,7 +25,7 @@ TESTABLE_FEATURES = [
 ]
 
 # Test wallet address behaviour across network upgrades
-class WalletDeprecationTest(BitcoinTestFramework):
+class WalletDeprecationTest(ZcashTestFramework):
     def __init__(self):
         super().__init__()
         self.num_nodes = 1
@@ -82,7 +82,7 @@ class WalletDeprecationTest(BitcoinTestFramework):
 
     def test_case(self, start_mode, features_to_allow, expected_state, default_enabled, default_disabled):
         stop_nodes(self.nodes)
-        wait_bitcoinds()
+        wait_nodes()
         start_mode(features_to_allow)
 
         for function in default_enabled:

--- a/qa/rpc-tests/wallet_doublespend.py
+++ b/qa/rpc-tests/wallet_doublespend.py
@@ -8,7 +8,7 @@ import os.path
 from decimal import Decimal
 
 from test_framework.mininode import COIN
-from test_framework.test_framework import BitcoinTestFramework
+from test_framework.test_framework import ZcashTestFramework
 from test_framework.util import (
     NU5_BRANCH_ID,
     assert_equal,
@@ -16,13 +16,13 @@ from test_framework.util import (
     nuparams,
     start_nodes,
     stop_nodes,
-    wait_bitcoinds,
+    wait_nodes,
     wait_and_assert_operationid_status,
 )
 from test_framework.zip317 import conventional_fee
 
 # Test wallet behaviour with the Orchard protocol
-class WalletDoubleSpendTest(BitcoinTestFramework):
+class WalletDoubleSpendTest(ZcashTestFramework):
     def __init__(self):
         super().__init__()
         self.num_nodes = 4
@@ -64,7 +64,7 @@ class WalletDoubleSpendTest(BitcoinTestFramework):
 
         # Shut down the nodes
         stop_nodes(self.nodes)
-        wait_bitcoinds()
+        wait_nodes()
 
         # Copy node 1's wallet to node 2
         tmpdir = self.options.tmpdir

--- a/qa/rpc-tests/wallet_golden_5_6_0.py
+++ b/qa/rpc-tests/wallet_golden_5_6_0.py
@@ -4,7 +4,7 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://www.opensource.org/licenses/mit-license.php .
 
-from test_framework.test_framework import BitcoinTestFramework
+from test_framework.test_framework import ZcashTestFramework
 from test_framework.util import (
     NU5_BRANCH_ID,
     assert_equal,
@@ -12,7 +12,7 @@ from test_framework.util import (
     nuparams,
     start_nodes,
     stop_nodes,
-    wait_bitcoinds,
+    wait_nodes,
     wait_and_assert_operationid_status,
     persistent_cache_exists,
     persist_node_caches,
@@ -20,7 +20,7 @@ from test_framework.util import (
 from decimal import Decimal
 
 
-class WalletGoldenV5_6_0Test(BitcoinTestFramework):
+class WalletGoldenV5_6_0Test(ZcashTestFramework):
     def __init__(self):
         super().__init__()
         self.num_nodes = 4
@@ -134,7 +134,7 @@ class WalletGoldenV5_6_0Test(BitcoinTestFramework):
 
             # Shut down the nodes
             stop_nodes(self.nodes)
-            wait_bitcoinds()
+            wait_nodes()
 
             # persist the node state to the cache
             persist_node_caches(self.options.tmpdir, 'golden-v5.6.0', 4)
@@ -156,7 +156,7 @@ class WalletGoldenV5_6_0Test(BitcoinTestFramework):
 
             # Shut down the nodes
             stop_nodes(self.nodes)
-            wait_bitcoinds()
+            wait_nodes()
 
             # persist the node state to the cache
             persist_node_caches(self.options.tmpdir, 'tarnished-v5.6.0', 4)

--- a/qa/rpc-tests/wallet_import_export.py
+++ b/qa/rpc-tests/wallet_import_export.py
@@ -4,10 +4,10 @@
 # file COPYING or https://www.opensource.org/licenses/mit-license.php .
 
 from test_framework.authproxy import JSONRPCException
-from test_framework.test_framework import BitcoinTestFramework
+from test_framework.test_framework import ZcashTestFramework
 from test_framework.util import assert_equal, assert_true, start_nodes
 
-class WalletImportExportTest (BitcoinTestFramework):
+class WalletImportExportTest (ZcashTestFramework):
     def setup_network(self, split=False):
         num_nodes = 3
         extra_args = [([

--- a/qa/rpc-tests/wallet_isfromme.py
+++ b/qa/rpc-tests/wallet_isfromme.py
@@ -3,7 +3,7 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://www.opensource.org/licenses/mit-license.php .
 
-from test_framework.test_framework import BitcoinTestFramework
+from test_framework.test_framework import ZcashTestFramework
 from test_framework.util import (
     BLOSSOM_BRANCH_ID,
     CANOPY_BRANCH_ID,
@@ -22,7 +22,7 @@ from test_framework.zip317 import conventional_fee
 
 from decimal import Decimal
 
-class WalletIsFromMe(BitcoinTestFramework):
+class WalletIsFromMe(ZcashTestFramework):
     def setup_chain(self):
         initialize_chain_clean(self.options.tmpdir, 1)
 

--- a/qa/rpc-tests/wallet_listnotes.py
+++ b/qa/rpc-tests/wallet_listnotes.py
@@ -3,7 +3,7 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://www.opensource.org/licenses/mit-license.php .
 
-from test_framework.test_framework import BitcoinTestFramework
+from test_framework.test_framework import ZcashTestFramework
 from test_framework.util import (
     NU5_BRANCH_ID,
     assert_equal,
@@ -18,7 +18,7 @@ from test_framework.zip317 import conventional_fee
 from decimal import Decimal
 
 # Test wallet z_listunspent behaviour across network upgrades
-class WalletListNotes(BitcoinTestFramework):
+class WalletListNotes(ZcashTestFramework):
     def __init__(self):
         super().__init__()
         self.cache_behavior = 'sprout'

--- a/qa/rpc-tests/wallet_listreceived.py
+++ b/qa/rpc-tests/wallet_listreceived.py
@@ -4,7 +4,7 @@
 # file COPYING or https://www.opensource.org/licenses/mit-license.php .
 
 from test_framework.authproxy import JSONRPCException
-from test_framework.test_framework import BitcoinTestFramework
+from test_framework.test_framework import ZcashTestFramework
 from test_framework.util import (
     assert_equal,
     assert_true,
@@ -24,7 +24,7 @@ my_memo = my_memo + '0'*(1024-len(my_memo))
 
 no_memo = 'f6' + ('0'*1022) # see section 5.5 of the protocol spec
 
-class ListReceivedTest (BitcoinTestFramework):
+class ListReceivedTest (ZcashTestFramework):
     def __init__(self):
         super().__init__()
         self.num_nodes = 3

--- a/qa/rpc-tests/wallet_listunspent.py
+++ b/qa/rpc-tests/wallet_listunspent.py
@@ -3,7 +3,7 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://www.opensource.org/licenses/mit-license.php .
 
-from test_framework.test_framework import BitcoinTestFramework
+from test_framework.test_framework import ZcashTestFramework
 from test_framework.mininode import COIN
 from test_framework.util import (
     assert_equal,
@@ -20,7 +20,7 @@ from decimal import Decimal
 def unspent_total(unspent):
     return sum((item['amount'] for item in unspent))
 
-class WalletListUnspent(BitcoinTestFramework):
+class WalletListUnspent(ZcashTestFramework):
     def setup_nodes(self):
         return start_nodes(4, self.options.tmpdir, extra_args=[[
             nuparams(NU5_BRANCH_ID, 201),

--- a/qa/rpc-tests/wallet_nullifiers.py
+++ b/qa/rpc-tests/wallet_nullifiers.py
@@ -3,15 +3,15 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://www.opensource.org/licenses/mit-license.php .
 
-from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import assert_equal, assert_true, bitcoind_processes, \
+from test_framework.test_framework import ZcashTestFramework
+from test_framework.util import assert_equal, assert_true, node_processes, \
     connect_nodes_bi, start_node, start_nodes, wait_and_assert_operationid_status, \
     get_coinbase_address
 from test_framework.zip317 import conventional_fee, ZIP_317_FEE
 
 from decimal import Decimal
 
-class WalletNullifiersTest (BitcoinTestFramework):
+class WalletNullifiersTest (ZcashTestFramework):
 
     def setup_nodes(self):
         return start_nodes(self.num_nodes, self.options.tmpdir, extra_args=[[
@@ -53,7 +53,7 @@ class WalletNullifiersTest (BitcoinTestFramework):
 
         # encrypt node 1 wallet and wait to terminate
         self.nodes[1].encryptwallet("test")
-        bitcoind_processes[1].wait()
+        node_processes[1].wait()
 
         # restart node 1
         self.nodes[1] = start_node(1, self.options.tmpdir, [

--- a/qa/rpc-tests/wallet_orchard.py
+++ b/qa/rpc-tests/wallet_orchard.py
@@ -3,7 +3,7 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://www.opensource.org/licenses/mit-license.php .
 
-from test_framework.test_framework import BitcoinTestFramework
+from test_framework.test_framework import ZcashTestFramework
 from test_framework.mininode import COIN
 from test_framework.util import (
     NU5_BRANCH_ID,
@@ -18,7 +18,7 @@ from test_framework.zip317 import conventional_fee
 from decimal import Decimal
 
 # Test wallet behaviour with the Orchard protocol
-class WalletOrchardTest(BitcoinTestFramework):
+class WalletOrchardTest(ZcashTestFramework):
     def __init__(self):
         super().__init__()
         self.num_nodes = 4

--- a/qa/rpc-tests/wallet_orchard_change.py
+++ b/qa/rpc-tests/wallet_orchard_change.py
@@ -5,7 +5,7 @@
 
 from decimal import Decimal
 
-from test_framework.test_framework import BitcoinTestFramework
+from test_framework.test_framework import ZcashTestFramework
 from test_framework.mininode import COIN
 from test_framework.util import (
     NU5_BRANCH_ID,
@@ -15,12 +15,12 @@ from test_framework.util import (
     start_nodes,
     stop_nodes,
     wait_and_assert_operationid_status,
-    wait_bitcoinds,
+    wait_nodes,
 )
 from test_framework.zip317 import conventional_fee, ZIP_317_FEE
 
 # Test wallet behaviour with the Orchard protocol
-class WalletOrchardChangeTest(BitcoinTestFramework):
+class WalletOrchardChangeTest(ZcashTestFramework):
     def __init__(self):
         super().__init__()
         self.num_nodes = 4
@@ -104,7 +104,7 @@ class WalletOrchardChangeTest(BitcoinTestFramework):
 
         # Shut down the nodes, and restart so that we can check wallet load
         stop_nodes(self.nodes)
-        wait_bitcoinds()
+        wait_nodes()
         self.setup_network()
 
         # The nodes have unaltered balances.

--- a/qa/rpc-tests/wallet_orchard_init.py
+++ b/qa/rpc-tests/wallet_orchard_init.py
@@ -8,7 +8,7 @@ import os.path
 
 from decimal import Decimal
 
-from test_framework.test_framework import BitcoinTestFramework
+from test_framework.test_framework import ZcashTestFramework
 from test_framework.mininode import COIN
 from test_framework.util import (
     NU5_BRANCH_ID,
@@ -17,13 +17,13 @@ from test_framework.util import (
     nuparams,
     start_nodes,
     stop_nodes,
-    wait_bitcoinds,
+    wait_nodes,
     wait_and_assert_operationid_status,
 )
 from test_framework.zip317 import conventional_fee, ZIP_317_FEE
 
 # Test wallet behaviour with the Orchard protocol
-class OrchardWalletInitTest(BitcoinTestFramework):
+class OrchardWalletInitTest(ZcashTestFramework):
     def __init__(self):
         super().__init__()
         self.num_nodes = 4
@@ -96,7 +96,7 @@ class OrchardWalletInitTest(BitcoinTestFramework):
 
         # Shut down the network and delete node 0's wallet
         stop_nodes(self.nodes)
-        wait_bitcoinds()
+        wait_nodes()
 
         tmpdir = self.options.tmpdir
         os.remove(os.path.join(tmpdir, "node0", "regtest", "wallet.dat"))

--- a/qa/rpc-tests/wallet_orchard_persistence.py
+++ b/qa/rpc-tests/wallet_orchard_persistence.py
@@ -3,7 +3,7 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://www.opensource.org/licenses/mit-license.php .
 
-from test_framework.test_framework import BitcoinTestFramework
+from test_framework.test_framework import ZcashTestFramework
 from test_framework.mininode import COIN
 from test_framework.util import (
     NU5_BRANCH_ID,
@@ -12,7 +12,7 @@ from test_framework.util import (
     nuparams,
     start_nodes,
     stop_nodes,
-    wait_bitcoinds,
+    wait_nodes,
     wait_and_assert_operationid_status,
 )
 from test_framework.zip317 import conventional_fee, ZIP_317_FEE
@@ -20,7 +20,7 @@ from test_framework.zip317 import conventional_fee, ZIP_317_FEE
 from decimal import Decimal
 
 # Test wallet behaviour with the Orchard protocol
-class WalletOrchardPersistenceTest(BitcoinTestFramework):
+class WalletOrchardPersistenceTest(ZcashTestFramework):
     def __init__(self):
         super().__init__()
         self.num_nodes = 4
@@ -89,7 +89,7 @@ class WalletOrchardPersistenceTest(BitcoinTestFramework):
 
         # Shut down the nodes, and restart so that we can check wallet load
         stop_nodes(self.nodes);
-        wait_bitcoinds()
+        wait_nodes()
         self.setup_network()
 
         balance0 -= conventional_fee(2)

--- a/qa/rpc-tests/wallet_orchard_reindex.py
+++ b/qa/rpc-tests/wallet_orchard_reindex.py
@@ -3,7 +3,7 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://www.opensource.org/licenses/mit-license.php .
 
-from test_framework.test_framework import BitcoinTestFramework
+from test_framework.test_framework import ZcashTestFramework
 from test_framework.mininode import COIN
 from test_framework.util import (
     NU5_BRANCH_ID,
@@ -14,7 +14,7 @@ from test_framework.util import (
     start_nodes,
     stop_nodes,
     wait_and_assert_operationid_status,
-    wait_bitcoinds,
+    wait_nodes,
 )
 from test_framework.zip317 import conventional_fee
 
@@ -27,7 +27,7 @@ BASE_ARGS = [
 ]
 
 # Test wallet behaviour when reindexing with Orchard state.
-class WalletOrchardReindexTest(BitcoinTestFramework):
+class WalletOrchardReindexTest(ZcashTestFramework):
     def setup_nodes(self):
         return start_nodes(self.num_nodes, self.options.tmpdir, extra_args=[BASE_ARGS] * self.num_nodes)
 
@@ -75,7 +75,7 @@ class WalletOrchardReindexTest(BitcoinTestFramework):
         # Restart the node with -reindex.
         blockcount = self.nodes[0].getblockcount()
         stop_nodes(self.nodes)
-        wait_bitcoinds()
+        wait_nodes()
         self.num_nodes = 1
         self.nodes = [start_node(0, self.options.tmpdir, BASE_ARGS + ['-reindex'])]
 

--- a/qa/rpc-tests/wallet_overwintertx.py
+++ b/qa/rpc-tests/wallet_overwintertx.py
@@ -3,7 +3,7 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://www.opensource.org/licenses/mit-license.php .
 
-from test_framework.test_framework import BitcoinTestFramework
+from test_framework.test_framework import ZcashTestFramework
 from test_framework.util import (
     assert_equal,
     assert_greater_than,
@@ -18,7 +18,7 @@ from test_framework.authproxy import JSONRPCException
 
 from decimal import Decimal
 
-class WalletOverwinterTxTest (BitcoinTestFramework):
+class WalletOverwinterTxTest (ZcashTestFramework):
 
     def __init__(self):
         super().__init__()

--- a/qa/rpc-tests/wallet_parsing_amounts.py
+++ b/qa/rpc-tests/wallet_parsing_amounts.py
@@ -3,13 +3,13 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://www.opensource.org/licenses/mit-license.php .
 
-from test_framework.test_framework import BitcoinTestFramework
+from test_framework.test_framework import ZcashTestFramework
 from test_framework.util import assert_equal, connect_nodes_bi, start_nodes
 from test_framework.authproxy import JSONRPCException
 from decimal import Decimal
 
 # Test wallet address behaviour across network upgrades
-class WalletAmountParsingTest(BitcoinTestFramework):
+class WalletAmountParsingTest(ZcashTestFramework):
     def setup_network(self, split=False):
         self.nodes = start_nodes(3, self.options.tmpdir, extra_args=[[
             '-allowdeprecated=getnewaddress',

--- a/qa/rpc-tests/wallet_persistence.py
+++ b/qa/rpc-tests/wallet_persistence.py
@@ -4,19 +4,19 @@
 # file COPYING or https://www.opensource.org/licenses/mit-license.php .
 
 from test_framework.mininode import COIN
-from test_framework.test_framework import BitcoinTestFramework
+from test_framework.test_framework import ZcashTestFramework
 from test_framework.util import (
     assert_equal, assert_true,
     get_coinbase_address,
     start_nodes, stop_nodes,
-    initialize_chain_clean, connect_nodes_bi, wait_bitcoinds,
+    initialize_chain_clean, connect_nodes_bi, wait_nodes,
     wait_and_assert_operationid_status
 )
 from test_framework.zip317 import conventional_fee
 
 from decimal import Decimal
 
-class WalletPersistenceTest (BitcoinTestFramework):
+class WalletPersistenceTest (ZcashTestFramework):
 
     def setup_chain(self):
         print("Initializing test directory " + self.options.tmpdir)
@@ -78,7 +78,7 @@ class WalletPersistenceTest (BitcoinTestFramework):
 
         # Restart the nodes
         stop_nodes(self.nodes)
-        wait_bitcoinds()
+        wait_nodes()
         self.setup_network()
 
         # Make sure we still have the address after restarting
@@ -120,7 +120,7 @@ class WalletPersistenceTest (BitcoinTestFramework):
 
         # Restart the nodes
         stop_nodes(self.nodes)
-        wait_bitcoinds()
+        wait_nodes()
         self.setup_network()
 
         # Verify size of pools
@@ -148,7 +148,7 @@ class WalletPersistenceTest (BitcoinTestFramework):
 
         # Restart the nodes
         stop_nodes(self.nodes)
-        wait_bitcoinds()
+        wait_nodes()
         self.setup_network()
 
         # Verify balances
@@ -169,7 +169,7 @@ class WalletPersistenceTest (BitcoinTestFramework):
 
         # Restart the nodes
         stop_nodes(self.nodes)
-        wait_bitcoinds()
+        wait_nodes()
         self.setup_network()
 
         # Verify nullifiers persisted correctly by checking balance

--- a/qa/rpc-tests/wallet_sapling.py
+++ b/qa/rpc-tests/wallet_sapling.py
@@ -3,7 +3,7 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://www.opensource.org/licenses/mit-license.php .
 
-from test_framework.test_framework import BitcoinTestFramework
+from test_framework.test_framework import ZcashTestFramework
 from test_framework.util import (
     assert_equal,
     get_coinbase_address,
@@ -15,7 +15,7 @@ from test_framework.zip317 import ZIP_317_FEE, conventional_fee
 from decimal import Decimal
 
 # Test wallet behaviour with Sapling addresses
-class WalletSaplingTest(BitcoinTestFramework):
+class WalletSaplingTest(ZcashTestFramework):
 
     def setup_nodes(self):
         return start_nodes(self.num_nodes, self.options.tmpdir, extra_args=[[

--- a/qa/rpc-tests/wallet_sendmany_any_taddr.py
+++ b/qa/rpc-tests/wallet_sendmany_any_taddr.py
@@ -5,7 +5,7 @@
 
 from decimal import Decimal
 
-from test_framework.test_framework import BitcoinTestFramework
+from test_framework.test_framework import ZcashTestFramework
 from test_framework.util import (
     assert_equal,
     assert_raises_message,
@@ -20,7 +20,7 @@ TX_EXPIRY_DELTA = 10
 TX_EXPIRING_SOON_THRESHOLD = 3
 
 # Test ANY_TADDR special string in z_sendmany
-class WalletSendManyAnyTaddr(BitcoinTestFramework):
+class WalletSendManyAnyTaddr(ZcashTestFramework):
     def setup_nodes(self):
         return start_nodes(self.num_nodes, self.options.tmpdir, extra_args=[[
             '-txexpirydelta=%d' % TX_EXPIRY_DELTA,

--- a/qa/rpc-tests/wallet_shieldcoinbase.py
+++ b/qa/rpc-tests/wallet_shieldcoinbase.py
@@ -3,7 +3,7 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://www.opensource.org/licenses/mit-license.php .
 
-from test_framework.test_framework import BitcoinTestFramework
+from test_framework.test_framework import ZcashTestFramework
 from test_framework.authproxy import JSONRPCException
 from test_framework.util import assert_equal, initialize_chain_clean, \
     start_node, connect_nodes_bi, sync_blocks, sync_mempools, \
@@ -13,7 +13,7 @@ from test_framework.zip317 import conventional_fee, ZIP_317_FEE
 
 from decimal import Decimal
 
-class WalletShieldCoinbaseTest (BitcoinTestFramework):
+class WalletShieldCoinbaseTest (ZcashTestFramework):
     def setup_chain(self):
         print("Initializing test directory "+self.options.tmpdir)
         initialize_chain_clean(self.options.tmpdir, 4)

--- a/qa/rpc-tests/wallet_shieldingcoinbase.py
+++ b/qa/rpc-tests/wallet_shieldingcoinbase.py
@@ -3,7 +3,7 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://www.opensource.org/licenses/mit-license.php .
 
-from test_framework.test_framework import BitcoinTestFramework
+from test_framework.test_framework import ZcashTestFramework
 from test_framework.authproxy import JSONRPCException
 from test_framework.mininode import COIN
 from test_framework.util import assert_equal, initialize_chain_clean, \
@@ -27,7 +27,7 @@ def check_value_pool(node, name, total):
             assert_equal(pool['chainValueZat'], total * COIN)
     assert(found)
 
-class WalletShieldingCoinbaseTest (BitcoinTestFramework):
+class WalletShieldingCoinbaseTest (ZcashTestFramework):
 
     def setup_chain(self):
         print("Initializing test directory "+self.options.tmpdir)

--- a/qa/rpc-tests/wallet_tarnished_5_6_0.py
+++ b/qa/rpc-tests/wallet_tarnished_5_6_0.py
@@ -4,7 +4,7 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://www.opensource.org/licenses/mit-license.php .
 
-from test_framework.test_framework import BitcoinTestFramework
+from test_framework.test_framework import ZcashTestFramework
 from test_framework.util import (
     NU5_BRANCH_ID,
     nuparams,
@@ -12,7 +12,7 @@ from test_framework.util import (
 )
 from wallet_golden_5_6_0 import golden_check_spendability
 
-class WalletTarnishedV5_6_0Test(BitcoinTestFramework):
+class WalletTarnishedV5_6_0Test(ZcashTestFramework):
     def __init__(self):
         super().__init__()
         self.num_nodes = 4

--- a/qa/rpc-tests/wallet_treestate.py
+++ b/qa/rpc-tests/wallet_treestate.py
@@ -3,7 +3,7 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://www.opensource.org/licenses/mit-license.php .
 
-from test_framework.test_framework import BitcoinTestFramework
+from test_framework.test_framework import ZcashTestFramework
 from test_framework.util import assert_equal, initialize_chain_clean, \
     start_nodes, connect_nodes_bi, wait_and_assert_operationid_status, \
     get_coinbase_address
@@ -12,7 +12,7 @@ from test_framework.zip317 import conventional_fee
 import time
 from decimal import Decimal
 
-class WalletTreeStateTest (BitcoinTestFramework):
+class WalletTreeStateTest (ZcashTestFramework):
 
     def setup_chain(self):
         print("Initializing test directory "+self.options.tmpdir)

--- a/qa/rpc-tests/wallet_unified_change.py
+++ b/qa/rpc-tests/wallet_unified_change.py
@@ -4,7 +4,7 @@
 # file COPYING or https://www.opensource.org/licenses/mit-license.php .
 
 from decimal import Decimal
-from test_framework.test_framework import BitcoinTestFramework
+from test_framework.test_framework import ZcashTestFramework
 from test_framework.util import (
     NU5_BRANCH_ID,
     assert_equal,
@@ -17,7 +17,7 @@ from test_framework.mininode import COIN
 from test_framework.zip317 import conventional_fee, ZIP_317_FEE
 
 # Test wallet accounts behaviour
-class WalletUnifiedChangeTest(BitcoinTestFramework):
+class WalletUnifiedChangeTest(ZcashTestFramework):
     def __init__(self):
         super().__init__()
         self.num_nodes = 4

--- a/qa/rpc-tests/wallet_z_sendmany.py
+++ b/qa/rpc-tests/wallet_z_sendmany.py
@@ -3,7 +3,7 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://www.opensource.org/licenses/mit-license.php .
 
-from test_framework.test_framework import BitcoinTestFramework
+from test_framework.test_framework import ZcashTestFramework
 from test_framework.util import (
     NU5_BRANCH_ID,
     assert_equal,
@@ -22,7 +22,7 @@ from test_framework.zip317 import conventional_fee, ZIP_317_FEE
 from decimal import Decimal
 
 # Test wallet address behaviour across network upgrades
-class WalletZSendmanyTest(BitcoinTestFramework):
+class WalletZSendmanyTest(ZcashTestFramework):
     def __init__(self):
         super().__init__()
         self.cache_behavior = 'sprout'

--- a/qa/rpc-tests/wallet_z_shieldcoinbase.py
+++ b/qa/rpc-tests/wallet_z_shieldcoinbase.py
@@ -32,7 +32,7 @@
 import time
 
 from decimal import Decimal
-from test_framework.test_framework import BitcoinTestFramework
+from test_framework.test_framework import ZcashTestFramework
 from test_framework.authproxy import JSONRPCException
 from test_framework.config import ZebraArgs
 from test_framework.util import (
@@ -137,7 +137,7 @@ def assert_in_message(e, needle):
     assert_true(needle in msg, "Expected {!r} in error, got: {!r}".format(needle, msg))
 
 
-class WalletZShieldCoinbaseTest(BitcoinTestFramework):
+class WalletZShieldCoinbaseTest(ZcashTestFramework):
 
     def __init__(self):
         super().__init__()

--- a/qa/rpc-tests/wallet_z_shieldcoinbase_multi_taddr.py
+++ b/qa/rpc-tests/wallet_z_shieldcoinbase_multi_taddr.py
@@ -46,7 +46,7 @@ import subprocess
 import time
 
 from decimal import Decimal
-from test_framework.test_framework import BitcoinTestFramework
+from test_framework.test_framework import ZcashTestFramework
 from test_framework.config import ZebraArgs
 from test_framework.util import (
     assert_equal,
@@ -57,7 +57,7 @@ from test_framework.util import (
     stop_node,
     stop_wallets,
     wait_and_assert_operationid_status,
-    wait_bitcoinds,
+    wait_nodes,
     wait_zallets,
     wallet_dir,
     zallet_binary,
@@ -82,7 +82,7 @@ def first_transparent_receiver(wallet, ua):
         "UA has no transparent receiver: {!r} -> {!r}".format(ua, receivers))
 
 
-class WalletZShieldCoinbaseMultiTaddrTest(BitcoinTestFramework):
+class WalletZShieldCoinbaseMultiTaddrTest(ZcashTestFramework):
 
     def __init__(self):
         super().__init__()
@@ -153,7 +153,7 @@ class WalletZShieldCoinbaseMultiTaddrTest(BitcoinTestFramework):
         stop_wallets(self.wallets)
         wait_zallets()
         stop_node(self.nodes[0], 0)
-        wait_bitcoinds()
+        wait_nodes()
 
         # Truncate the wallet's block-scan state so it no longer holds
         # records for heights zebrad is about to lose. After shutdown

--- a/qa/rpc-tests/wallet_zero_value.py
+++ b/qa/rpc-tests/wallet_zero_value.py
@@ -3,12 +3,12 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://www.opensource.org/licenses/mit-license.php .
 
-from test_framework.test_framework import BitcoinTestFramework
+from test_framework.test_framework import ZcashTestFramework
 from test_framework.util import assert_equal, connect_nodes_bi, start_nodes
 from decimal import Decimal
 
 # Test wallet address behaviour across network upgrades
-class WalletZeroValueTest(BitcoinTestFramework):
+class WalletZeroValueTest(ZcashTestFramework):
     def setup_network(self, split=False):
         self.nodes = start_nodes(2, self.options.tmpdir, extra_args=[[
             '-allowdeprecated=getnewaddress',

--- a/qa/rpc-tests/wallet_zip317_default.py
+++ b/qa/rpc-tests/wallet_zip317_default.py
@@ -5,7 +5,7 @@
 
 from decimal import Decimal
 
-from test_framework.test_framework import BitcoinTestFramework
+from test_framework.test_framework import ZcashTestFramework
 from test_framework.mininode import COIN
 from test_framework.util import (
     CANOPY_BRANCH_ID,
@@ -20,7 +20,7 @@ from test_framework.util import (
 from test_framework.zip317 import conventional_fee, ZIP_317_FEE
 
 # Regression test for https://github.com/zcash/zcash/issues/6956 .
-class WalletZip317DefaultTest(BitcoinTestFramework):
+class WalletZip317DefaultTest(ZcashTestFramework):
     def __init__(self):
         super().__init__()
         self.num_nodes = 2

--- a/qa/rpc-tests/walletbackup.py
+++ b/qa/rpc-tests/walletbackup.py
@@ -34,7 +34,7 @@ Shutdown again, restore using importwallet,
 and confirm again balances are correct.
 """
 
-from test_framework.test_framework import BitcoinTestFramework
+from test_framework.test_framework import ZcashTestFramework
 from test_framework.authproxy import JSONRPCException
 from test_framework.util import assert_equal, \
     start_nodes, start_node, connect_nodes, stop_node, \
@@ -49,7 +49,7 @@ import sys
 
 logging.basicConfig(format='%(levelname)s: %(message)s', level=logging.INFO, stream=sys.stdout)
 
-class WalletBackupTest(BitcoinTestFramework):
+class WalletBackupTest(ZcashTestFramework):
 
     def __init__(self):
         super().__init__()

--- a/qa/rpc-tests/zapwallettxes.py
+++ b/qa/rpc-tests/zapwallettxes.py
@@ -6,13 +6,13 @@
 
 from time import sleep
 
-from test_framework.test_framework import BitcoinTestFramework
+from test_framework.test_framework import ZcashTestFramework
 from test_framework.authproxy import JSONRPCException
 from test_framework.util import assert_equal, \
-    start_nodes, start_node, connect_nodes_bi, bitcoind_processes
+    start_nodes, start_node, connect_nodes_bi, node_processes
 
 
-class ZapWalletTXesTest (BitcoinTestFramework):
+class ZapWalletTXesTest (ZcashTestFramework):
 
     def __init__(self):
         super().__init__()
@@ -61,14 +61,14 @@ class ZapWalletTXesTest (BitcoinTestFramework):
 
         # restart zcashd
         self.nodes[0].stop()
-        bitcoind_processes[0].wait()
+        node_processes[0].wait()
         self.nodes[0] = start_node(0,self.options.tmpdir)
 
         tx3 = self.nodes[0].gettransaction(txid3)
         assert_equal(tx3['txid'], txid3) # tx must be available (unconfirmed)
 
         self.nodes[0].stop()
-        bitcoind_processes[0].wait()
+        node_processes[0].wait()
 
         # restart zcashd with zapwallettxes
         self.nodes[0] = start_node(0,self.options.tmpdir, ["-zapwallettxes=1"])

--- a/qa/rpc-tests/zkey_import_export.py
+++ b/qa/rpc-tests/zkey_import_export.py
@@ -4,7 +4,7 @@
 # file COPYING or https://www.opensource.org/licenses/mit-license.php .
 
 from decimal import Decimal
-from test_framework.test_framework import BitcoinTestFramework
+from test_framework.test_framework import ZcashTestFramework
 from test_framework.authproxy import JSONRPCException
 from test_framework.util import (
     assert_equal, assert_greater_than, assert_raises_message, start_nodes,
@@ -18,7 +18,7 @@ import sys
 
 logging.basicConfig(format='%(levelname)s: %(message)s', level=logging.INFO, stream=sys.stdout)
 
-class ZkeyImportExportTest (BitcoinTestFramework):
+class ZkeyImportExportTest (ZcashTestFramework):
 
     def setup_chain(self):
         print("Initializing test directory "+self.options.tmpdir)

--- a/qa/rpc-tests/zmq_test.py
+++ b/qa/rpc-tests/zmq_test.py
@@ -8,13 +8,13 @@
 # Test ZMQ interface
 #
 
-from test_framework.test_framework import BitcoinTestFramework
+from test_framework.test_framework import ZcashTestFramework
 from test_framework.util import assert_equal, bytes_to_hex_str, start_nodes
 
 import zmq
 import struct
 
-class ZMQTest(BitcoinTestFramework):
+class ZMQTest(ZcashTestFramework):
 
     def __init__(self):
         super().__init__()


### PR DESCRIPTION
Feel free to close if you disagree with the renaming - don't lose much time reading if it is contraversary, I don't have a strong opinion. This is an automated patch generated by Claude in the background while onboarding on the code.

---

Closes #110. Builds on #108 (stacked: base is `chore/rename-node-helpers`;
retarget to `main` once #108 merges).

The test framework descends from Bitcoin Core via zcashd and kept the
inherited naming even though the node under test is `zebrad`. This renames
the widely-used public API for clarity:

- `BitcoinTestFramework` -> `ZcashTestFramework`
- `bitcoind_processes` -> `node_processes`
- `wait_bitcoinds` -> `wait_nodes`

Plus node-related comments, docstrings, and a loop variable in the
framework (e.g. "Start a bitcoind" -> "Start a node").

Mechanical, repo-wide rename (~129 files). Left unchanged on purpose:
copyright headers ("The Bitcoin Core developers"), references to external
projects (python-bitcoinrpc, bitcoinj, bitcoinlib), the `ZCASHD_BINARY`
constant used by not-yet-migrated EXTENDED tests, and the already-accurate
node-generic names (`start_node`/`start_nodes`, `connect_nodes`).

Verified locally: all files parse and `getmininginfo.py` / `nuparams.py`
still pass.