### PR TITLE
Fix endless running tests

### DIFF
--- a/qa/rpc-tests/mempool_nu_activation.py
+++ b/qa/rpc-tests/mempool_nu_activation.py
@@ -3,15 +3,10 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://www.opensource.org/licenses/mit-license.php .
 
+from test_framework.config import ZebraArgs
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
-    BLOSSOM_BRANCH_ID,
-    CANOPY_BRANCH_ID,
-    HEARTWOOD_BRANCH_ID,
-    NU5_BRANCH_ID,
-    NU6_BRANCH_ID,
     assert_equal, assert_true,
-    nuparams,
     start_node, connect_nodes, wait_and_assert_operationid_status,
     get_coinbase_address
 )
@@ -30,20 +25,13 @@ class MempoolUpgradeActivationTest(BitcoinTestFramework):
         self.cache_behavior = 'clean'
 
     def setup_network(self):
-        args = [
-            '-checkmempool',
-            '-debug=mempool',
-            '-blockmaxsize=4000',
-            '-preferredtxversion=4',
-            '-allowdeprecated=getnewaddress',
-            '-allowdeprecated=z_getnewaddress',
-            '-allowdeprecated=z_getbalance',
-            nuparams(BLOSSOM_BRANCH_ID, 200),
-            nuparams(HEARTWOOD_BRANCH_ID, 210),
-            nuparams(CANOPY_BRANCH_ID, 220),
-            nuparams(NU5_BRANCH_ID, 230),
-            nuparams(NU6_BRANCH_ID, 240),
-        ]
+        args = ZebraArgs(activation_heights={
+            "Blossom": 200,
+            "Heartwood": 210,
+            "Canopy": 220,
+            "NU5": 230,
+            "NU6": 240,
+        })
         self.nodes = []
         self.nodes.append(start_node(0, self.options.tmpdir, args))
         self.nodes.append(start_node(1, self.options.tmpdir, args))

--- a/qa/rpc-tests/test_framework/test_framework.py
+++ b/qa/rpc-tests/test_framework/test_framework.py
@@ -220,16 +220,19 @@ class BitcoinTestFramework(object):
 
         if not self.options.noshutdown:
             print("Stopping wallets")
-            stop_wallets(self.wallets)
-            wait_zallets()
+            if self.wallets is not None:
+                stop_wallets(self.wallets)
+                wait_zallets()
 
             print("Stopping indexers")
-            stop_zainos(self.zainos)
-            wait_zainods()
+            if self.zainos is not None:
+                stop_zainos(self.zainos)
+                wait_zainods()
 
             print("Stopping nodes")
-            stop_nodes(self.nodes)
-            wait_bitcoinds()
+            if self.nodes is not None:
+                stop_nodes(self.nodes)
+                wait_bitcoinds()
 
             # self.nodes, self.wallets and self.zainos migth not contain all
             # running processes, `util` keeps global dicts or running processes

--- a/qa/rpc-tests/test_framework/test_framework.py
+++ b/qa/rpc-tests/test_framework/test_framework.py
@@ -27,6 +27,7 @@ from .util import (
     connect_nodes_bi,
     sync_blocks,
     sync_mempools,
+    stop_all_processes,
     stop_nodes,
     stop_wallets,
     stop_zainos,
@@ -229,6 +230,10 @@ class BitcoinTestFramework(object):
             print("Stopping nodes")
             stop_nodes(self.nodes)
             wait_bitcoinds()
+
+            # self.nodes, self.wallets and self.zainos migth not contain all
+            # running processes, `util` keeps global dicts or running processes
+            stop_all_processes()
         else:
             print("Note: zebrads, zainods, and zallets were not stopped and may still be running")
 

--- a/qa/rpc-tests/test_framework/util.py
+++ b/qa/rpc-tests/test_framework/util.py
@@ -1223,3 +1223,18 @@ def wait_zainods():
             pass
         wait_or_kill(zainod)
     zainod_processes.clear()
+
+def stop_all_processes():
+    '''
+    Forcibly terminate every zebrad, zainod and zallet process we spawned,
+    regardless of whether a test data structure still references it.
+    '''
+    for processes in (bitcoind_processes, zallet_processes, zainod_processes):
+        for p in list(processes.values()):
+            try:
+                p.terminate() # send SIGHIGH
+            except Exception:
+                pass
+        for p in list(processes.values()):
+            wait_or_kill(p)
+        processes.clear()


### PR DESCRIPTION
This is a human review of some changes from https://github.com/zcash/integration-tests/pull/104/.

This patch fixes the uncomfortable issue we have when running a test: not all processes are shutdown, and the stdout gets flooded by remaining running process outputs.

To test. Before:
```
uv run python3 qa/rpc-tests/mempool_nu_activation.py
```
won't kill all running processes.
After it does.

This patch does not make the CI green, yet. It will be in an upcoming patch.

Reviews can happen commit by commit.