### PR TITLE
test: align regtest NU5 activation between zebra and zallet

### DIFF
--- a/qa/rpc-tests/test_framework/config.py
+++ b/qa/rpc-tests/test_framework/config.py
@@ -9,7 +9,8 @@ from typing import Any
 @dataclass
 class ZebraArgs:
     miner_address: str = "tmSRd1r8gs77Ja67Fw1JcdoXytxsyrLTPJm"
-    activation_heights: dict[str, int] = field(default_factory=dict)
+    # Match zallet.toml's regtest NU5@height-1, else create_cache.py hits "Missing Orchard tree state".
+    activation_heights: dict[str, int] = field(default_factory=lambda: {"NU5": 1})
     funding_streams: list[dict[str, Any]] = field(default_factory=list)
     lockbox_disbursements: list[dict[str, Any]] = field(default_factory=list)
 


### PR DESCRIPTION
zallet's regtest config activates NU5 at height 1, but zebra's `ZebraArgs.activation_heights` defaults to empty, so `create_cache.py` crashes with "Missing Orchard tree state" before any test runs — failing the required CI shards.

Aligning the zebra default to `{"NU5": 1}` fixes it. Verified locally on zebra v5.0.0: the full 8-node cache builds cleanly (height 200, 0 Orchard errors); without it, sync is stuck at height ~2. NU5 alone is sufficient. Approach from #104.

Unblocks #125 (rebasing it on this should go green). Note: this PR's own shards stay red until #125 also lands, since the not-yet-migrated tests still run here — the two are complementary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)