### PR TITLE
Disable flaky addnode.py

### DIFF
--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -45,6 +45,7 @@ FLAKY_SCRIPTS = [
 # migration. Most "deprecated" RPCs are deprecated in zcashd and map to zallet's
 # account/UA API.
 DISABLED_SCRIPTS = [
+    'addnode.py',  # flaky: zebra regtest block broadcast/peering stalls in multi-peer topologies (cf zebra #10332/#10329)
     'addressindex.py',  # deprecated; getnewaddress->z_getaddressforaccount, getbalance->z_getbalances
     'bip65-cltv-p2p.py',  # P2P/mininode framework
     'bipdersig-p2p.py',  # P2P/mininode framework


### PR DESCRIPTION
`addnode.py` is flaky (~1/3 pass): blocks intermittently fail to propagate between regtest nodes, so cross-node sync times out. It's a zebra regtest broadcast/peering issue, not a test-logic bug — a node-restart workaround doesn't recover it.

Disabling so required CI is deterministic. See zebra #10332 / #10329 for context.

Previously running (and failing) in CI here:
https://github.com/zcash/integration-tests/actions/runs/27422360610/job/81053801290