### PR TITLE
qa: share z_shieldcoinbase test helpers via util.py

### DIFF
--- a/qa/rpc-tests/test_framework/util.py
+++ b/qa/rpc-tests/test_framework/util.py
@@ -1452,6 +1452,51 @@ def mature_transparent_utxos(wallet: RpcProxy) -> list[dict]:
     return transparent_utxos(wallet, COINBASE_MATURITY)
 
 
+def mature_coinbase_on_address(wallet: RpcProxy, taddr: str) -> list[dict]:
+    """The wallet's mature transparent coinbase UTXOs held on `taddr`."""
+    return [u for u in mature_transparent_utxos(wallet)
+            if u.get('address') == taddr]
+
+
+def first_transparent_receiver(wallet: RpcProxy, ua: str) -> str:
+    """Return the transparent (P2PKH, else P2SH) receiver of a unified address
+    created with a transparent component."""
+    receivers = wallet.z_listunifiedreceivers(ua)
+    if 'p2pkh' in receivers:
+        return receivers['p2pkh']
+    if 'p2sh' in receivers:
+        return receivers['p2sh']
+    raise AssertionError(
+        "UA has no transparent receiver: {!r} -> {!r}".format(ua, receivers))
+
+
+def nu_activation_all_at_1() -> dict:
+    """Activation heights putting every network upgrade at height 1, the
+    standard Z3-stack wallet-test regtest config (NU5+ active from height 1).
+
+    Returns a fresh dict on each call so callers can pass it to `ZebraArgs`
+    without sharing mutable state."""
+    return {"NU5": 1, "NU6": 1, "NU6.1": 1, "NU6.2": 1}
+
+
+def assert_shieldcoinbase_preflight_shape(result: dict) -> None:
+    """Assert the `z_shieldcoinbase` pre-flight response has the zcashd-shaped
+    fields with the right types:
+    `{ remainingUTXOs, remainingValue, shieldingUTXOs, shieldingValue, opid }`."""
+    assert_true(isinstance(result, dict),
+                "Expected dict, got {}: {!r}".format(type(result), result))
+    for key in ('remainingUTXOs', 'remainingValue',
+                'shieldingUTXOs', 'shieldingValue', 'opid'):
+        assert_true(key in result,
+                    "Missing field {!r} in response: {!r}".format(key, result))
+    assert_true(isinstance(result['remainingUTXOs'], int))
+    assert_true(isinstance(result['shieldingUTXOs'], int))
+    assert_true(isinstance(result['opid'], str))
+    # remainingValue / shieldingValue are JSON numbers; Decimal-able.
+    Decimal(result['remainingValue'])
+    Decimal(result['shieldingValue'])
+
+
 def wait_for_stable_transparent(wallet: RpcProxy, min_count: int = 1,
                                 minconf: int = 1, timeout: int = 300,
                                 settle_secs: int = COINBASE_SETTLE_SECS) -> list[dict]:

--- a/qa/rpc-tests/wallet_z_shieldcoinbase.py
+++ b/qa/rpc-tests/wallet_z_shieldcoinbase.py
@@ -36,8 +36,10 @@ from test_framework.util import (
     COINBASE_MATURITY,
     assert_equal,
     assert_in_message,
+    assert_shieldcoinbase_preflight_shape,
     assert_true,
     expect_rpc_error,
+    nu_activation_all_at_1,
     start_nodes,
     wait_and_assert_operationid_status,
     wait_and_assert_operationid_status_result,
@@ -72,7 +74,7 @@ class WalletZShieldCoinbaseTest(BitcoinTestFramework):
         args = [
             ZebraArgs(
                 miner_address=addr,
-                activation_heights={"NU5": 1, "NU6": 1, "NU6.1": 1, "NU6.2": 1},
+                activation_heights=nu_activation_all_at_1(),
             ) for addr in self.miner_addresses
         ]
         return start_nodes(self.num_nodes, self.options.tmpdir, args)
@@ -225,17 +227,6 @@ class WalletZShieldCoinbaseTest(BitcoinTestFramework):
                     .format(good_policy, msg))
         print("  PASSED")
 
-    @staticmethod
-    def _first_transparent_receiver(wallet, ua):
-        """Return the P2PKH receiver of a UA created with a transparent component."""
-        receivers = wallet.z_listunifiedreceivers(ua)
-        if 'p2pkh' in receivers:
-            return receivers['p2pkh']
-        if 'p2sh' in receivers:
-            return receivers['p2sh']
-        raise AssertionError(
-            "UA has no transparent receiver: {!r} -> {!r}".format(ua, receivers))
-
     # ------------------------------------------------------------------
     # Functional tests: require mature coinbase.
     # ------------------------------------------------------------------
@@ -275,7 +266,7 @@ class WalletZShieldCoinbaseTest(BitcoinTestFramework):
         print("  [diag] mature coinbase UTXO count={}".format(n_expected))
 
         result = w0.z_shieldcoinbase(w0_taddr, w0_zaddr)
-        self._assert_preflight_shape(result)
+        assert_shieldcoinbase_preflight_shape(result)
         assert_equal(result['shieldingUTXOs'], n_expected)
         assert_equal(result['remainingUTXOs'], 0)
         assert_equal(Decimal(result['remainingValue']), Decimal('0'))
@@ -301,7 +292,7 @@ class WalletZShieldCoinbaseTest(BitcoinTestFramework):
         n_expected = len(wait_for_mature_coinbase_count(w0, expected_unspent_mature()))
 
         result = w0.z_shieldcoinbase(w0_account_uuid, w0_zaddr)
-        self._assert_preflight_shape(result)
+        assert_shieldcoinbase_preflight_shape(result)
         assert_equal(result['shieldingUTXOs'], n_expected,
                      "UUID-form should sweep every mature coinbase")
         assert_equal(result['remainingUTXOs'], 0)
@@ -322,7 +313,7 @@ class WalletZShieldCoinbaseTest(BitcoinTestFramework):
 
         # toaddress is a UA on a different account; fromaddress need not own it.
         result = w0.z_shieldcoinbase(w0_taddr, w0_extra_zaddr)
-        self._assert_preflight_shape(result)
+        assert_shieldcoinbase_preflight_shape(result)
         assert_equal(result['shieldingUTXOs'], n_expected)
         assert_equal(result['remainingUTXOs'], 0)
         assert_equal(Decimal(result['remainingValue']), Decimal('0'))
@@ -350,7 +341,7 @@ class WalletZShieldCoinbaseTest(BitcoinTestFramework):
         # Sweep 1: capped at `limit`; the rest are reported as remaining.
         # Positional signature: (fromaddress, toaddress, fee, limit, ...)
         result1 = w0.z_shieldcoinbase(w0_taddr, w0_zaddr, None, limit)
-        self._assert_preflight_shape(result1)
+        assert_shieldcoinbase_preflight_shape(result1)
         assert_equal(result1['shieldingUTXOs'], limit)
         assert_equal(result1['remainingUTXOs'], n_eligible - limit)
         shielding_value1 = Decimal(result1['shieldingValue'])
@@ -365,7 +356,7 @@ class WalletZShieldCoinbaseTest(BitcoinTestFramework):
         # sweep 1's now-spent inputs, so it must drain exactly what sweep 1
         # reported as remaining — backend-anchored, no snapshot summing.
         result2 = w0.z_shieldcoinbase(w0_taddr, w0_zaddr)
-        self._assert_preflight_shape(result2)
+        assert_shieldcoinbase_preflight_shape(result2)
         assert_equal(result2['shieldingUTXOs'], remaining_utxos1,
                      "2nd sweep must drain exactly sweep 1's remaining UTXOs")
         assert_equal(Decimal(result2['shieldingValue']), remaining_value1,
@@ -397,7 +388,7 @@ class WalletZShieldCoinbaseTest(BitcoinTestFramework):
 
         huge_limit = n_eligible + 1000
         result = w0.z_shieldcoinbase(w0_taddr, w0_zaddr, None, huge_limit)
-        self._assert_preflight_shape(result)
+        assert_shieldcoinbase_preflight_shape(result)
         # Cap above eligible has no effect: everything is swept.
         assert_equal(result['shieldingUTXOs'], n_eligible)
         assert_equal(result['remainingUTXOs'], 0)
@@ -421,7 +412,7 @@ class WalletZShieldCoinbaseTest(BitcoinTestFramework):
 
         # Positional signature: (fromaddress, toaddress, fee, limit, memo, ...)
         result = w0.z_shieldcoinbase(w0_taddr, w0_zaddr, None, None, my_memo)
-        self._assert_preflight_shape(result)
+        assert_shieldcoinbase_preflight_shape(result)
         assert_equal(result['shieldingUTXOs'], n_expected)
         assert_equal(result['remainingUTXOs'], 0)
         assert_equal(Decimal(result['remainingValue']), Decimal('0'))
@@ -451,7 +442,7 @@ class WalletZShieldCoinbaseTest(BitcoinTestFramework):
         n_expected = len(wait_for_mature_coinbase_count(w0, expected_unspent_mature()))
 
         result = w0.z_shieldcoinbase(w0_taddr, w0_zaddr)
-        self._assert_preflight_shape(result)
+        assert_shieldcoinbase_preflight_shape(result)
         assert_equal(result['shieldingUTXOs'], n_expected)
         assert_equal(result['remainingUTXOs'], 0)
         assert_equal(Decimal(result['remainingValue']), Decimal('0'))
@@ -478,24 +469,6 @@ class WalletZShieldCoinbaseTest(BitcoinTestFramework):
         assert_equal(len(remaining), 0)
         mature_spent += n_expected
         print("  PASSED")
-
-    # ------------------------------------------------------------------
-    # Helpers
-    # ------------------------------------------------------------------
-
-    def _assert_preflight_shape(self, result):
-        assert_true(isinstance(result, dict),
-                    "Expected dict, got {}: {!r}".format(type(result), result))
-        for key in ('remainingUTXOs', 'remainingValue',
-                    'shieldingUTXOs', 'shieldingValue', 'opid'):
-            assert_true(key in result,
-                        "Missing field {!r} in response: {!r}".format(key, result))
-        assert_true(isinstance(result['remainingUTXOs'], int))
-        assert_true(isinstance(result['shieldingUTXOs'], int))
-        assert_true(isinstance(result['opid'], str))
-        # remainingValue / shieldingValue are JSON numbers; Decimal-able.
-        Decimal(result['remainingValue'])
-        Decimal(result['shieldingValue'])
 
     # ------------------------------------------------------------------
 

--- a/qa/rpc-tests/wallet_z_shieldcoinbase_multi_taddr.py
+++ b/qa/rpc-tests/wallet_z_shieldcoinbase_multi_taddr.py
@@ -47,8 +47,12 @@ from test_framework.util import (
     COINBASE_MATURITY,
     COINBASE_SETTLE_SECS,
     assert_equal,
+    assert_shieldcoinbase_preflight_shape,
     assert_true,
+    first_transparent_receiver,
+    mature_coinbase_on_address,
     node_dir,
+    nu_activation_all_at_1,
     start_node,
     start_nodes,
     start_wallets,
@@ -58,16 +62,6 @@ from test_framework.util import (
     wait_bitcoinds,
     wait_zallets,
 )
-
-
-def first_transparent_receiver(wallet, ua):
-    receivers = wallet.z_listunifiedreceivers(ua)
-    if 'p2pkh' in receivers:
-        return receivers['p2pkh']
-    if 'p2sh' in receivers:
-        return receivers['p2sh']
-    raise AssertionError(
-        "UA has no transparent receiver: {!r} -> {!r}".format(ua, receivers))
 
 
 class WalletZShieldCoinbaseMultiTaddrTest(BitcoinTestFramework):
@@ -87,18 +81,10 @@ class WalletZShieldCoinbaseMultiTaddrTest(BitcoinTestFramework):
         args = [
             ZebraArgs(
                 miner_address=addr,
-                activation_heights={"NU5": 1, "NU6": 1, "NU6.1": 1, "NU6.2": 1},
+                activation_heights=nu_activation_all_at_1(),
             ) for addr in self.miner_addresses
         ]
         return start_nodes(self.num_nodes, self.options.tmpdir, args)
-
-    def _mature_coinbase_on(self, wallet, taddr):
-        # minconf = COINBASE_MATURITY matches the proposal (coinbase is
-        # spendable at exactly 100 confirmations); minconf+1 would miss a
-        # boundary UTXO the sweep selects.
-        utxos = wallet.z_listunspent(COINBASE_MATURITY)
-        return [u for u in utxos
-                if u.get('pool') == 'transparent' and u.get('address') == taddr]
 
     def run_test(self):
         node = self.nodes[0]
@@ -184,8 +170,7 @@ class WalletZShieldCoinbaseMultiTaddrTest(BitcoinTestFramework):
         self.nodes[0] = start_node(
             0, self.options.tmpdir,
             ZebraArgs(miner_address=taddr_b,
-                      activation_heights={"NU5": 1, "NU6": 1,
-                                          "NU6.1": 1, "NU6.2": 1}))
+                      activation_heights=nu_activation_all_at_1()))
         node = self.nodes[0]
         # zebra must have restored exactly block 1 (A's coinbase). If the backup
         # had not captured it, the restored tip would be genesis and the premise
@@ -211,8 +196,8 @@ class WalletZShieldCoinbaseMultiTaddrTest(BitcoinTestFramework):
         mature_b = []
         stable_secs = 0
         while time.time() < deadline:
-            mature_a = self._mature_coinbase_on(w0, taddr_a)
-            mature_b = self._mature_coinbase_on(w0, taddr_b)
+            mature_a = mature_coinbase_on_address(w0, taddr_a)
+            mature_b = mature_coinbase_on_address(w0, taddr_b)
             if len(mature_a) == 1 and len(mature_b) == 1:
                 stable_secs += 1
                 if stable_secs >= COINBASE_SETTLE_SECS:
@@ -254,9 +239,7 @@ class WalletZShieldCoinbaseMultiTaddrTest(BitcoinTestFramework):
         result = w0.z_shieldcoinbase(account_uuid, zaddr, None, None, None, None)
 
         # Pre-flight shape sanity.
-        for key in ('remainingUTXOs', 'remainingValue',
-                    'shieldingUTXOs', 'shieldingValue', 'opid'):
-            assert_true(key in result, "Missing field {!r} in response".format(key))
+        assert_shieldcoinbase_preflight_shape(result)
 
         # Sweep must select exactly the two mature coinbases — one
         # from each receiver. Anything other than 2 means either the


### PR DESCRIPTION
Consolidate logic duplicated across the two z_shieldcoinbase tests into util.py: first_transparent_receiver, mature_coinbase_on_address, assert_shieldcoinbase_preflight_shape, and nu_activation_all_at_1.

Both tests now import these instead of defining local copies; the dead _first_transparent_receiver static method and the _assert_preflight_shape and _mature_coinbase_on methods are removed. No behavior change.