### PR TITLE
ci: decouple build-only platforms and run tests on ubuntu-latest

### DIFF
--- a/.github/workflows/build-binary.yml
+++ b/.github/workflows/build-binary.yml
@@ -1,0 +1,222 @@
+name: Build binary
+
+# Reusable workflow that builds a single binary (zebrad, zainod, or the zallet
+# launcher plus its zaino backend) for a given set of platforms. It is called
+# twice per binary from `ci.yml`: once for the platforms the tests run on, and
+# once for the build-only platforms (macOS, Windows, cross-compiled targets).
+# Splitting the matrix this way lets the test jobs depend only on the builds
+# they actually consume, instead of waiting for every platform to finish
+# building.
+
+on:
+  workflow_call:
+    inputs:
+      build_matrix:
+        description: JSON array of platform configs to build.
+        required: true
+        type: string
+      repository:
+        description: The owner/name of the source repository to build.
+        required: true
+        type: string
+      default_ref:
+        description: The git ref to build when not handling an interop request.
+        required: true
+        type: string
+      interop_action:
+        description: The repository_dispatch action that pins this binary's commit.
+        required: true
+        type: string
+      path:
+        description: Path to check the source out into (also the cargo workspace).
+        required: true
+        type: string
+      bin:
+        description: The cargo binary (and artifact name prefix) to build.
+        required: true
+        type: string
+      job_name_prefix:
+        description: Prefix for the per-platform job and interop status name.
+        required: true
+        type: string
+      is_zallet:
+        description: Whether to apply zallet-specific build and packaging steps.
+        required: false
+        type: boolean
+        default: false
+    secrets:
+      STATUS_APP_ID:
+        description: Status-reporting GitHub App ID (for interop requests).
+        required: true
+      STATUS_APP_PRIVATE_KEY:
+        description: Status-reporting GitHub App private key.
+        required: true
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: ${{ inputs.job_name_prefix }} ${{ matrix.platform }}${{ matrix.required_suffix }}
+    runs-on: ${{ matrix.build_os }}
+    container:
+      image: ${{ matrix.container }}
+      env:
+        HOME: /root
+        PATH: /root/.cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:$PATH
+    continue-on-error: ${{ !matrix.required }}
+    strategy:
+      matrix:
+        include: ${{ fromJson(inputs.build_matrix) }}
+
+    steps:
+      - name: Check out integration-tests to access actions
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          path: integration-tests
+          persist-credentials: false
+
+      - name: Compute interop repo ids
+        id: repo-ids
+        uses: ./integration-tests/.github/actions/interop-repo-ids
+
+      - id: start-interop
+        uses: ./integration-tests/.github/actions/start-interop
+        with:
+          status-app-id: ${{ secrets.STATUS_APP_ID }}
+          status-app-private-key: ${{ secrets.STATUS_APP_PRIVATE_KEY }}
+          requesting-owner: ${{ steps.repo-ids.outputs.requesting-owner }}
+          requesting-repository: ${{ steps.repo-ids.outputs.requesting-repository }}
+          job-name: "${{ inputs.job_name_prefix }} ${{ matrix.platform }}${{ matrix.required_suffix }}"
+
+      - name: Use specified commit
+        if: github.event.action == inputs.interop_action
+        shell: sh
+        env:
+          SHA: ${{ github.event.client_payload.sha }}
+        run: echo "TARGET_REF=${SHA}" >> $GITHUB_ENV
+
+      - name: Use current default branch
+        if: github.event.action != inputs.interop_action
+        env:
+          DEFAULT_REF: ${{ inputs.default_ref }}
+        run: echo "TARGET_REF=${DEFAULT_REF}" >> $GITHUB_ENV
+
+      - name: Check out ${{ inputs.repository }}
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: ${{ inputs.repository }}
+          ref: ${{ env.TARGET_REF }}
+          path: ${{ inputs.path }}
+          persist-credentials: false
+
+      - name: Install Homebrew build dependencies
+        if: matrix.brew_deps != ''
+        run: brew install ${{ matrix.brew_deps }}
+
+      - name: Install cross-compilation build dependencies
+        if: matrix.cross_deps != ''
+        run: sudo apt update && sudo apt install ${{ matrix.cross_deps }}
+
+      - name: Configure MinGW to use POSIX variant
+        if: matrix.name == 'mingw32'
+        run: |
+          sudo update-alternatives --set x86_64-w64-mingw32-gcc $(update-alternatives --query x86_64-w64-mingw32-gcc | grep Alternative | grep posix | cut -d' ' -f2)
+          sudo update-alternatives --set x86_64-w64-mingw32-g++ $(update-alternatives --query x86_64-w64-mingw32-g++ | grep Alternative | grep posix | cut -d' ' -f2)
+
+      - name: Prepare ccache timestamp
+        id: ccache_cache_timestamp
+        shell: bash
+        run: echo "timestamp=$(date +'%Y-%m-%d-%H;%M;%S')" >> "$GITHUB_OUTPUT"
+
+      - name: Cache ccache files
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ${{ runner.os == 'macOS' && '~/Library/Caches/ccache' || '~/.cache/ccache' }}
+          key: ${{ matrix.name }}-ccache-${{ steps.ccache_cache_timestamp.outputs.timestamp }}
+          restore-keys: |
+            ${{ matrix.name }}-ccache-
+
+      - name: Cache cargo build (single workspace)
+        if: ${{ !inputs.is_zallet }}
+        uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
+        with:
+          key: ${{ matrix.name }}
+          workspaces: "./${{ inputs.path }}"
+
+      - name: Cache cargo build (zallet launcher + zaino backend)
+        if: ${{ inputs.is_zallet }}
+        uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
+        with:
+          key: ${{ matrix.name }}
+          # zallet is two workspaces: the root (the `zallet` launcher) and
+          # backends/zaino (the `zallet-zaino` backend binary), each with its
+          # own target directory. Cache both.
+          workspaces: |
+            zallet
+            zallet/backends/zaino
+
+      - name: Install Rust target
+        run: rustup target add ${{ matrix.rust_target }}
+        working-directory: ./${{ inputs.path }}
+
+      - name: Build ${{ inputs.bin }}
+        if: ${{ !inputs.is_zallet }}
+        env:
+          HOST: ${{ matrix.host }}
+          CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: "aarch64-linux-gnu-gcc"
+          BIN: ${{ inputs.bin }}
+        run: cargo build --release --target ${{ matrix.rust_target }} --bin "${BIN}"
+        working-directory: ./${{ inputs.path }}
+
+      # Build the `zallet` launcher plus the `zallet-zaino` backend binary the
+      # regtest suite needs. See .github/scripts/build-zallet.sh. zcashd-import is
+      # disabled on mingw32: its pqcrypto-mlkem dep fails to cross-compile to
+      # windows-gnu, and the tests needing it are Linux-only.
+      - name: Build zallet
+        if: ${{ inputs.is_zallet }}
+        env:
+          HOST: ${{ matrix.host }}
+          CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: "aarch64-linux-gnu-gcc"
+          RUST_TARGET: ${{ matrix.rust_target }}
+          FILE_EXT: ${{ matrix.file_ext }}
+          ZCASHD_IMPORT: ${{ matrix.name != 'mingw32' && '--features zcashd-import' || '' }}
+        shell: bash
+        working-directory: ./zallet
+        run: "${{ github.workspace }}/integration-tests/.github/scripts/build-zallet.sh"
+
+      - name: Stage vendored db_dump
+        if: ${{ inputs.is_zallet && matrix.name != 'mingw32' && runner.os != 'Windows' }}
+        shell: bash
+        working-directory: ./zallet
+        run: "${{ github.workspace }}/integration-tests/.github/scripts/stage-zallet-db-dump.sh"
+
+      - name: Upload ${{ inputs.bin }}
+        if: ${{ !inputs.is_zallet }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: ${{ inputs.bin }}-${{ matrix.name }}
+          path: |
+              ${{ format('./{0}/target/{1}/release/{2}{3}', inputs.path, matrix.rust_target, inputs.bin, matrix.file_ext) }}
+
+      # Upload the launcher, the Zaino backend binary, and the vendored db_dump.
+      # They land flat in ./src on the test runners; the launcher finds a sibling
+      # zallet-zaino next to itself.
+      - name: Upload zallet
+        if: ${{ inputs.is_zallet }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: zallet-${{ matrix.name }}
+          path: |
+              ${{ format('./zallet/dist/zallet{0}', matrix.file_ext) }}
+              ${{ format('./zallet/dist/zallet-zaino{0}', matrix.file_ext) }}
+              ./zallet/dist/db_dump
+          if-no-files-found: warn
+
+      - uses: ./integration-tests/.github/actions/finish-interop
+        if: always()
+        with:
+          app-token: ${{ steps.start-interop.outputs.app-token }}
+          requesting-owner: ${{ steps.repo-ids.outputs.requesting-owner }}
+          requesting-repository: ${{ steps.repo-ids.outputs.requesting-repository }}
+          job-name: "${{ inputs.job_name_prefix }} ${{ matrix.platform }}${{ matrix.required_suffix }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,6 +128,7 @@ jobs:
       build_names: ${{ steps.set-matrices.outputs.build_names }}
       test_build_matrix: ${{ steps.set-matrices.outputs.test_build_matrix }}
       extra_build_matrix: ${{ steps.set-matrices.outputs.extra_build_matrix }}
+      python_version: ${{ steps.python-version.outputs.version }}
       test_matrix: ${{ steps.set-matrices.outputs.test_matrix }}
       test_names: ${{ steps.set-matrices.outputs.test_names }}
       unix_test_matrix: ${{ steps.set-matrices.outputs.unix_test_matrix }}
@@ -154,6 +155,22 @@ jobs:
           # Empty on direct repo PRs, which selects the default.
           ref: ${{ steps.test-branch.outputs.test_sha }}
           persist-credentials: false
+
+      # Source the Python version for the test jobs from the uv lockfile, so it
+      # has a single point of definition and follows the project's pin. We take
+      # the minimal version from `requires-python` (e.g. "==3.11.*" -> "3.11");
+      # the RPC test framework (qa/rpc-tests) is not compatible with newer
+      # Python (it uses the asyncore module removed in 3.12), so ubuntu-latest's
+      # default interpreter cannot run it.
+      - id: python-version
+        run: |
+          version=$(grep -m1 '^requires-python' uv.lock \
+            | grep -oE '[0-9]+\.[0-9]+' | head -1)
+          if [ -z "$version" ]; then
+            echo "Could not read requires-python from uv.lock" >&2
+            exit 1
+          fi
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
 
       # When triggered by repository_dispatch, callers may specify a subset of
       # platforms to run via client_payload.platforms (a JSON array of platform
@@ -514,12 +531,17 @@ jobs:
         include: ${{ fromJson(needs.setup.outputs.rpc_test_matrix) }}
 
     steps:
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: ${{ needs.setup.outputs.python_version }}
+
       - name: Cache Python dependencies for RPC tests
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           enableCrossOsArchive: true
           path: venv
-          key: test-rpc-venv-${{ matrix.name }}
+          key: test-rpc-venv-${{ matrix.name }}-py${{ needs.setup.outputs.python_version }}
 
       - name: Get Python dependencies for RPC tests
         run: |
@@ -580,12 +602,17 @@ jobs:
           requesting-repository: ${{ steps.repo-ids.outputs.requesting-repository }}
           job-name: "RPC tests ${{ matrix.platform }} ${{ matrix.shard }}${{ matrix.required_suffix }}"
 
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: ${{ needs.setup.outputs.python_version }}
+
       - name: Cache Python dependencies for RPC tests
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           enableCrossOsArchive: true
           path: venv
-          key: test-rpc-venv-${{ matrix.name }}
+          key: test-rpc-venv-${{ matrix.name }}-py${{ needs.setup.outputs.python_version }}
 
       - name: Get Python dependencies for RPC tests if not cached
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,11 +63,22 @@ jobs:
             #   host: x86_64-pc-linux-gnu
             #   rust_target: x86_64-unknown-linux-gnu
 
-            - name: ubuntu-22.04
+            # The tests run on ubuntu-latest (the required test platform). We
+            # additionally build on the pinned ubuntu-22.04 and ubuntu-24.04
+            # images for build coverage, but no test runs on them (they have no
+            # test_os), so they do not gate CI or block the tests.
+            - name: ubuntu-latest
               required: true
+              platform: Ubuntu (latest)
+              build_os: ubuntu-latest
+              test_os: ubuntu-latest
+              host: x86_64-pc-linux-gnu
+              rust_target: x86_64-unknown-linux-gnu
+
+            - name: ubuntu-22.04
+              required: false
               platform: Ubuntu 22.04
               build_os: ${{ vars.UBUNTU_22_04_LARGE_RUNNER || 'ubuntu-22.04' }}
-              test_os: ubuntu-22.04
               host: x86_64-pc-linux-gnu
               rust_target: x86_64-unknown-linux-gnu
 
@@ -75,7 +86,6 @@ jobs:
               required: false
               platform: Ubuntu 24.04
               build_os: ubuntu-24.04
-              test_os: ubuntu-24.04
               host: x86_64-pc-linux-gnu
               rust_target: x86_64-unknown-linux-gnu
 
@@ -116,6 +126,8 @@ jobs:
     outputs:
       build_matrix: ${{ steps.set-matrices.outputs.build_matrix }}
       build_names: ${{ steps.set-matrices.outputs.build_names }}
+      test_build_matrix: ${{ steps.set-matrices.outputs.test_build_matrix }}
+      extra_build_matrix: ${{ steps.set-matrices.outputs.extra_build_matrix }}
       test_matrix: ${{ steps.set-matrices.outputs.test_matrix }}
       test_names: ${{ steps.set-matrices.outputs.test_names }}
       unix_test_matrix: ${{ steps.set-matrices.outputs.unix_test_matrix }}
@@ -200,6 +212,13 @@ jobs:
         run: |
           jq -r -n 'env.CFG | fromjson | @json "build_matrix=\(.data)"' >> $GITHUB_OUTPUT
           jq -r -n 'env.CFG | fromjson | [.data[] | .name] | @json "build_names=\(.)"' >> $GITHUB_OUTPUT
+          # Split the build matrix into the platforms the tests actually consume
+          # artifacts for, and the build-only platforms (cross-compiled targets
+          # and Windows, which no job here tests). This lets the test jobs depend
+          # only on the former, instead of blocking on every platform's build.
+          # The two selects are exact complements, so they partition the matrix.
+          jq -r -n 'env.CFG | fromjson | [.data[] | select(.test_os and (.test_os != "windows-latest" or .required))] | @json "test_build_matrix=\(.)"' >> $GITHUB_OUTPUT
+          jq -r -n 'env.CFG | fromjson | [.data[] | select((.test_os | not) or (.test_os == "windows-latest" and (.required | not)))] | @json "extra_build_matrix=\(.)"' >> $GITHUB_OUTPUT
           jq -r -n 'env.CFG | fromjson | [.data[] | select(.test_os)] | @json "test_matrix=\(.)"' >> $GITHUB_OUTPUT
           jq -r -n 'env.CFG | fromjson | [.data[] | select(.test_os) | .name] | @json "test_names=\(.)"' >> $GITHUB_OUTPUT
           jq -r -n 'env.CFG | fromjson | [.data[] | select(.test_os and .test_os != "windows-latest")] | @json "unix_test_matrix=\(.)"' >> $GITHUB_OUTPUT
@@ -285,359 +304,110 @@ jobs:
           mkdir zcash-params || echo ""
           curl -L -C - https://download.z.cash/downloads/sprout-groth16.params -o zcash-params/sprout-groth16.params
 
+  # Each binary is built by the reusable build-binary.yml workflow, called twice:
+  # `build-<bin>` builds the platforms the tests consume, and `build-<bin>-extra`
+  # builds the remaining build-only platforms (Windows, cross-compiled targets,
+  # macOS). The test jobs depend only on the `build-<bin>` jobs, so they no
+  # longer wait for the build-only platforms. The `if` guards skip a call when
+  # its slice of the matrix is empty (possible for a platform-filtered interop
+  # request), which avoids an empty build matrix.
   build-zebra:
-    name: Build zebrad on ${{ matrix.platform }}${{ matrix.required_suffix }}
     needs: setup
-    runs-on: ${{ matrix.build_os }}
-    container:
-      image: ${{ matrix.container }}
-      env:
-        HOME: /root
-        PATH: /root/.cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:$PATH
-    continue-on-error: ${{ !matrix.required }}
-    strategy:
-      matrix:
-        include: ${{ fromJson(needs.setup.outputs.build_matrix) }}
+    if: ${{ needs.setup.outputs.test_build_matrix != '[]' }}
+    uses: ./.github/workflows/build-binary.yml
+    secrets:
+      STATUS_APP_ID: ${{ secrets.STATUS_APP_ID }}
+      STATUS_APP_PRIVATE_KEY: ${{ secrets.STATUS_APP_PRIVATE_KEY }}
+    with:
+      build_matrix: ${{ needs.setup.outputs.test_build_matrix }}
+      repository: ZcashFoundation/zebra
+      default_ref: refs/heads/main
+      interop_action: zebra-interop-request
+      path: zebra
+      bin: zebrad
+      job_name_prefix: Build zebrad on
 
-    steps:
-      - name: Check out integration-tests to access actions
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          path: integration-tests
-          persist-credentials: false
-
-      - name: Compute interop repo ids
-        id: repo-ids
-        uses: ./integration-tests/.github/actions/interop-repo-ids
-
-      - id: start-interop
-        uses: ./integration-tests/.github/actions/start-interop
-        with:
-          status-app-id: ${{ secrets.STATUS_APP_ID }}
-          status-app-private-key: ${{ secrets.STATUS_APP_PRIVATE_KEY }}
-          requesting-owner: ${{ steps.repo-ids.outputs.requesting-owner }}
-          requesting-repository: ${{ steps.repo-ids.outputs.requesting-repository }}
-          job-name: "Build zebrad on ${{ matrix.platform }}${{ matrix.required_suffix }}"
-
-      - name: Use specified ZcashFoundation/zebra commit
-        if: github.event.action == 'zebra-interop-request'
-        shell: sh
-        env:
-          SHA: ${{ github.event.client_payload.sha }}
-        run: echo "ZEBRA_REF=${SHA}" >> $GITHUB_ENV
-
-      - name: Use ZcashFoundation/zebra current main
-        if: github.event.action != 'zebra-interop-request'
-        run: echo "ZEBRA_REF=refs/heads/main" >> $GITHUB_ENV
-
-      - name: Check out ZcashFoundation/zebra
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          repository: ZcashFoundation/zebra
-          ref: ${{ env.ZEBRA_REF }}
-          path: zebra
-
-      - name: Install Homebrew build dependencies
-        if: matrix.brew_deps != ''
-        run: brew install ${{ matrix.brew_deps }}
-
-      - name: Install cross-compilation build dependencies
-        if: matrix.cross_deps != ''
-        run: sudo apt update && sudo apt install ${{ matrix.cross_deps }}
-
-      - name: Configure MinGW to use POSIX variant
-        if: matrix.name == 'mingw32'
-        run: |
-          sudo update-alternatives --set x86_64-w64-mingw32-gcc $(update-alternatives --query x86_64-w64-mingw32-gcc | grep Alternative | grep posix | cut -d' ' -f2)
-          sudo update-alternatives --set x86_64-w64-mingw32-g++ $(update-alternatives --query x86_64-w64-mingw32-g++ | grep Alternative | grep posix | cut -d' ' -f2)
-
-      - name: Prepare ccache timestamp
-        id: ccache_cache_timestamp
-        shell: bash
-        run: echo "timestamp=$(date +'%Y-%m-%d-%H;%M;%S')" >> "$GITHUB_OUTPUT"
-
-      - name: Cache ccache files
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: ${{ runner.os == 'macOS' && '~/Library/Caches/ccache' || '~/.cache/ccache' }}
-          key: ${{ matrix.name }}-ccache-${{ steps.ccache_cache_timestamp.outputs.timestamp }}
-          restore-keys: |
-            ${{ matrix.name }}-ccache-
-
-      - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
-        with:
-          key: ${{ matrix.name }}
-          workspaces: "./zebra"
-
-      - name: Install Rust target
-        run: rustup target add ${{ matrix.rust_target }}
-        working-directory: ./zebra
-
-      - name: Build zebrad
-        env:
-          HOST: ${{ matrix.host }}
-          CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: "aarch64-linux-gnu-gcc"
-        run: cargo build --release --target ${{ matrix.rust_target }} --bin zebrad
-        working-directory: ./zebra
-
-      - name: Upload zebrad
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        with:
-          name: zebrad-${{ matrix.name }}
-          path: |
-              ${{ format('./zebra/target/{0}/release/zebrad{1}', matrix.rust_target, matrix.file_ext) }}
-
-      - uses: ./integration-tests/.github/actions/finish-interop
-        if: always()
-        with:
-          app-token: ${{ steps.start-interop.outputs.app-token }}
-          requesting-owner: ${{ steps.repo-ids.outputs.requesting-owner }}
-          requesting-repository: ${{ steps.repo-ids.outputs.requesting-repository }}
-          job-name: "Build zebrad on ${{ matrix.platform }}${{ matrix.required_suffix }}"
+  build-zebra-extra:
+    needs: setup
+    if: ${{ needs.setup.outputs.extra_build_matrix != '[]' }}
+    uses: ./.github/workflows/build-binary.yml
+    secrets:
+      STATUS_APP_ID: ${{ secrets.STATUS_APP_ID }}
+      STATUS_APP_PRIVATE_KEY: ${{ secrets.STATUS_APP_PRIVATE_KEY }}
+    with:
+      build_matrix: ${{ needs.setup.outputs.extra_build_matrix }}
+      repository: ZcashFoundation/zebra
+      default_ref: refs/heads/main
+      interop_action: zebra-interop-request
+      path: zebra
+      bin: zebrad
+      job_name_prefix: Build zebrad on
 
   build-zaino:
-    name: Build zainod on ${{ matrix.platform }}${{ matrix.required_suffix }}
     needs: setup
-    runs-on: ${{ matrix.build_os }}
-    container:
-      image: ${{ matrix.container }}
-      env:
-        HOME: /root
-        PATH: /root/.cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:$PATH
-    continue-on-error: ${{ !matrix.required }}
-    strategy:
-      matrix:
-        include: ${{ fromJson(needs.setup.outputs.build_matrix) }}
+    if: ${{ needs.setup.outputs.test_build_matrix != '[]' }}
+    uses: ./.github/workflows/build-binary.yml
+    secrets:
+      STATUS_APP_ID: ${{ secrets.STATUS_APP_ID }}
+      STATUS_APP_PRIVATE_KEY: ${{ secrets.STATUS_APP_PRIVATE_KEY }}
+    with:
+      build_matrix: ${{ needs.setup.outputs.test_build_matrix }}
+      repository: zingolabs/zaino
+      default_ref: refs/heads/dev
+      interop_action: zaino-interop-request
+      path: zaino
+      bin: zainod
+      job_name_prefix: Build zainod on
 
-    steps:
-      - name: Check out integration-tests to access actions
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          path: integration-tests
-          persist-credentials: false
-
-      - name: Compute interop repo ids
-        id: repo-ids
-        uses: ./integration-tests/.github/actions/interop-repo-ids
-
-      - id: start-interop
-        uses: ./integration-tests/.github/actions/start-interop
-        with:
-          status-app-id: ${{ secrets.STATUS_APP_ID }}
-          status-app-private-key: ${{ secrets.STATUS_APP_PRIVATE_KEY }}
-          requesting-owner: ${{ steps.repo-ids.outputs.requesting-owner }}
-          requesting-repository: ${{ steps.repo-ids.outputs.requesting-repository }}
-          job-name: "Build zainod on ${{ matrix.platform }}${{ matrix.required_suffix }}"
-
-      - name: Use specified zingolabs/zaino commit
-        if: github.event.action == 'zaino-interop-request'
-        shell: sh
-        env:
-          SHA: ${{ github.event.client_payload.sha }}
-        run: echo "ZAINO_REF=${SHA}" >> $GITHUB_ENV
-
-      - name: Use zingolabs/zaino current dev
-        if: github.event.action != 'zaino-interop-request'
-        run: echo "ZAINO_REF=refs/heads/dev" >> $GITHUB_ENV
-
-      - name: Check out zingolabs/zaino
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          repository: zingolabs/zaino
-          ref: ${{ env.ZAINO_REF }}
-          path: zaino
-
-      - name: Install Homebrew build dependencies
-        if: matrix.brew_deps != ''
-        run: brew install ${{ matrix.brew_deps }}
-
-      - name: Install cross-compilation build dependencies
-        if: matrix.cross_deps != ''
-        run: sudo apt update && sudo apt install ${{ matrix.cross_deps }}
-
-      - name: Configure MinGW to use POSIX variant
-        if: matrix.name == 'mingw32'
-        run: |
-          sudo update-alternatives --set x86_64-w64-mingw32-gcc $(update-alternatives --query x86_64-w64-mingw32-gcc | grep Alternative | grep posix | cut -d' ' -f2)
-          sudo update-alternatives --set x86_64-w64-mingw32-g++ $(update-alternatives --query x86_64-w64-mingw32-g++ | grep Alternative | grep posix | cut -d' ' -f2)
-
-      - name: Prepare ccache timestamp
-        id: ccache_cache_timestamp
-        shell: bash
-        run: echo "timestamp=$(date +'%Y-%m-%d-%H;%M;%S')" >> "$GITHUB_OUTPUT"
-
-      - name: Cache ccache files
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: ${{ runner.os == 'macOS' && '~/Library/Caches/ccache' || '~/.cache/ccache' }}
-          key: ${{ matrix.name }}-ccache-${{ steps.ccache_cache_timestamp.outputs.timestamp }}
-          restore-keys: |
-            ${{ matrix.name }}-ccache-
-
-      - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
-        with:
-          key: ${{ matrix.name }}
-          workspaces: "./zaino"
-
-      - name: Install Rust target
-        run: rustup target add ${{ matrix.rust_target }}
-        working-directory: ./zaino
-
-      - name: Build zainod
-        env:
-          HOST: ${{ matrix.host }}
-          CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: "aarch64-linux-gnu-gcc"
-        run: cargo build --release --target ${{ matrix.rust_target }} --bin zainod
-        working-directory: ./zaino
-
-      - name: Upload zainod
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        with:
-          name: zainod-${{ matrix.name }}
-          path: |
-              ${{ format('./zaino/target/{0}/release/zainod{1}', matrix.rust_target, matrix.file_ext) }}
-
-      - uses: ./integration-tests/.github/actions/finish-interop
-        if: always()
-        with:
-          app-token: ${{ steps.start-interop.outputs.app-token }}
-          requesting-owner: ${{ steps.repo-ids.outputs.requesting-owner }}
-          requesting-repository: ${{ steps.repo-ids.outputs.requesting-repository }}
-          job-name: "Build zainod on ${{ matrix.platform }}${{ matrix.required_suffix }}"
+  build-zaino-extra:
+    needs: setup
+    if: ${{ needs.setup.outputs.extra_build_matrix != '[]' }}
+    uses: ./.github/workflows/build-binary.yml
+    secrets:
+      STATUS_APP_ID: ${{ secrets.STATUS_APP_ID }}
+      STATUS_APP_PRIVATE_KEY: ${{ secrets.STATUS_APP_PRIVATE_KEY }}
+    with:
+      build_matrix: ${{ needs.setup.outputs.extra_build_matrix }}
+      repository: zingolabs/zaino
+      default_ref: refs/heads/dev
+      interop_action: zaino-interop-request
+      path: zaino
+      bin: zainod
+      job_name_prefix: Build zainod on
 
   build-zallet:
-    name: Build zallet on ${{ matrix.platform }}${{ matrix.required_suffix }}
     needs: setup
-    runs-on: ${{ matrix.build_os }}
-    container:
-      image: ${{ matrix.container }}
-      env:
-        HOME: /root
-        PATH: /root/.cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:$PATH
-    continue-on-error: ${{ !matrix.required }}
-    strategy:
-      matrix:
-        include: ${{ fromJson(needs.setup.outputs.build_matrix) }}
+    if: ${{ needs.setup.outputs.test_build_matrix != '[]' }}
+    uses: ./.github/workflows/build-binary.yml
+    secrets:
+      STATUS_APP_ID: ${{ secrets.STATUS_APP_ID }}
+      STATUS_APP_PRIVATE_KEY: ${{ secrets.STATUS_APP_PRIVATE_KEY }}
+    with:
+      build_matrix: ${{ needs.setup.outputs.test_build_matrix }}
+      repository: zcash/zallet
+      default_ref: refs/heads/main
+      interop_action: zallet-interop-request
+      path: zallet
+      bin: zallet
+      job_name_prefix: Build zallet on
+      is_zallet: true
 
-    steps:
-      - name: Check out integration-tests to access actions
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          path: integration-tests
-          persist-credentials: false
-
-      - name: Compute interop repo ids
-        id: repo-ids
-        uses: ./integration-tests/.github/actions/interop-repo-ids
-
-      - id: start-interop
-        uses: ./integration-tests/.github/actions/start-interop
-        with:
-          status-app-id: ${{ secrets.STATUS_APP_ID }}
-          status-app-private-key: ${{ secrets.STATUS_APP_PRIVATE_KEY }}
-          requesting-owner: ${{ steps.repo-ids.outputs.requesting-owner }}
-          requesting-repository: ${{ steps.repo-ids.outputs.requesting-repository }}
-          job-name: "Build zallet on ${{ matrix.platform }}${{ matrix.required_suffix }}"
-
-      - name: Use specified zcash/zallet commit
-        if: github.event.action == 'zallet-interop-request'
-        shell: sh
-        env:
-          SHA: ${{ github.event.client_payload.sha }}
-        run: echo "ZALLET_REF=${SHA}" >> $GITHUB_ENV
-      - name: Use zcash/zallet current main
-        if: github.event.action != 'zallet-interop-request'
-        run: echo "ZALLET_REF=refs/heads/main" >> $GITHUB_ENV
-
-      - name: Check out zcash/zallet
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          repository: zcash/zallet
-          ref: ${{ env.ZALLET_REF }}
-          path: zallet
-
-      - name: Install Homebrew build dependencies
-        if: matrix.brew_deps != ''
-        run: brew install ${{ matrix.brew_deps }}
-
-      - name: Install cross-compilation build dependencies
-        if: matrix.cross_deps != ''
-        run: sudo apt update && sudo apt install ${{ matrix.cross_deps }}
-
-      - name: Configure MinGW to use POSIX variant
-        if: matrix.name == 'mingw32'
-        run: |
-          sudo update-alternatives --set x86_64-w64-mingw32-gcc $(update-alternatives --query x86_64-w64-mingw32-gcc | grep Alternative | grep posix | cut -d' ' -f2)
-          sudo update-alternatives --set x86_64-w64-mingw32-g++ $(update-alternatives --query x86_64-w64-mingw32-g++ | grep Alternative | grep posix | cut -d' ' -f2)
-
-      - name: Prepare ccache timestamp
-        id: ccache_cache_timestamp
-        shell: bash
-        run: echo "timestamp=$(date +'%Y-%m-%d-%H;%M;%S')" >> "$GITHUB_OUTPUT"
-
-      - name: Cache ccache files
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: ${{ runner.os == 'macOS' && '~/Library/Caches/ccache' || '~/.cache/ccache' }}
-          key: ${{ matrix.name }}-ccache-${{ steps.ccache_cache_timestamp.outputs.timestamp }}
-          restore-keys: |
-            ${{ matrix.name }}-ccache-
-
-      - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
-        with:
-          key: ${{ matrix.name }}
-          # zallet is two workspaces: the root (the `zallet` launcher) and
-          # backends/zaino (the `zallet-zaino` backend binary), each with its
-          # own target directory. Cache both.
-          workspaces: |
-            zallet
-            zallet/backends/zaino
-
-      - name: Install Rust target
-        run: rustup target add ${{ matrix.rust_target }}
-        working-directory: ./zallet
-
-      # Build the `zallet` launcher plus the `zallet-zaino` backend binary the
-      # regtest suite needs. See .github/scripts/build-zallet.sh. zcashd-import is
-      # disabled on mingw32: its pqcrypto-mlkem dep fails to cross-compile to
-      # windows-gnu, and the tests needing it are Linux-only.
-      - name: Build zallet
-        env:
-          HOST: ${{ matrix.host }}
-          CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: "aarch64-linux-gnu-gcc"
-          RUST_TARGET: ${{ matrix.rust_target }}
-          FILE_EXT: ${{ matrix.file_ext }}
-          ZCASHD_IMPORT: ${{ matrix.name != 'mingw32' && '--features zcashd-import' || '' }}
-        shell: bash
-        working-directory: ./zallet
-        run: "${{ github.workspace }}/integration-tests/.github/scripts/build-zallet.sh"
-
-      - name: Stage vendored db_dump
-        if: matrix.name != 'mingw32' && runner.os != 'Windows'
-        shell: bash
-        working-directory: ./zallet
-        run: "${{ github.workspace }}/integration-tests/.github/scripts/stage-zallet-db-dump.sh"
-
-      # Upload the launcher, the Zaino backend binary, and the vendored db_dump.
-      # They land flat in ./src on the test runners; the launcher finds a sibling
-      # zallet-zaino next to itself.
-      - name: Upload zallet
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        with:
-          name: zallet-${{ matrix.name }}
-          path: |
-              ${{ format('./zallet/dist/zallet{0}', matrix.file_ext) }}
-              ${{ format('./zallet/dist/zallet-zaino{0}', matrix.file_ext) }}
-              ./zallet/dist/db_dump
-          if-no-files-found: warn
-
-      - uses: ./integration-tests/.github/actions/finish-interop
-        if: always()
-        with:
-          app-token: ${{ steps.start-interop.outputs.app-token }}
-          requesting-owner: ${{ steps.repo-ids.outputs.requesting-owner }}
-          requesting-repository: ${{ steps.repo-ids.outputs.requesting-repository }}
-          job-name: "Build zallet on ${{ matrix.platform }}${{ matrix.required_suffix }}"
+  build-zallet-extra:
+    needs: setup
+    if: ${{ needs.setup.outputs.extra_build_matrix != '[]' }}
+    uses: ./.github/workflows/build-binary.yml
+    secrets:
+      STATUS_APP_ID: ${{ secrets.STATUS_APP_ID }}
+      STATUS_APP_PRIVATE_KEY: ${{ secrets.STATUS_APP_PRIVATE_KEY }}
+    with:
+      build_matrix: ${{ needs.setup.outputs.extra_build_matrix }}
+      repository: zcash/zallet
+      default_ref: refs/heads/main
+      interop_action: zallet-interop-request
+      path: zallet
+      bin: zallet
+      job_name_prefix: Build zallet on
+      is_zallet: true
 
   # Not working in Windows
   sec-hard:

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -2,3 +2,4 @@ rules:
   secrets-outside-env:
     ignore:
       - ci.yml
+      - build-binary.yml


### PR DESCRIPTION
Rebased onto zcash/integration-tests#150 (the Zallet launcher-plus-backend
split).

## Problem

`sec-hard` and `test-rpc` run only on Ubuntu, but they declared
`needs: [build-zebra, build-zaino, build-zallet]`. Because `needs` on a matrix
job blocks on the **whole** matrix, the tests waited for the macOS, Windows
(mingw32), and cross-compiled aarch64 builds to finish before starting, even
though they never download those artifacts.

## Change

- Factor the per-binary build steps into a reusable workflow
  (`.github/workflows/build-binary.yml`) so the logic is defined once instead of
  triplicated.
- Call it twice per binary: `build-<bin>` builds the platforms the tests
  consume, and `build-<bin>-extra` builds the remaining build-only platforms.
- `sec-hard` and `test-rpc` now depend only on the `build-<bin>` jobs, so they
  no longer block on the build-only platforms.
- Move the required test platform to **ubuntu-latest**, and keep building on the
  pinned **ubuntu-22.04** and **ubuntu-24.04** images for build coverage. Those
  two have no `test_os`, so they are build-only: they do not gate CI or block
  the tests.
- `setup` emits two complementary matrices that partition the build matrix:
  `test_build_matrix` (a non-Windows `test_os`, or a required one →
  `{ubuntu-latest}`) and `extra_build_matrix` (everything else →
  `{ubuntu-22.04, ubuntu-24.04, mingw32, aarch64-linux}`). An `if` guard skips a
  build call when its slice is empty (e.g. a platform-filtered interop request).

## Effect on the critical path

Before, the required test jobs could not start until every platform (Windows,
macOS, aarch64) had finished building. Now they start as soon as the
ubuntu-latest builds are ready; the build-only platforms run in parallel and
off the critical path.

## Behaviors preserved

- Per-platform job names keep the `(required)` suffix that `ci-status.yml` uses
  to detect required jobs.
- The `repository_dispatch` interop context (`github.event.action`,
  `client_payload`) is available in the reusable workflow, so interop requests
  and per-platform status reporting are unchanged.
- The zallet build keeps the launcher-plus-`zallet-zaino`-backend structure from
  #150, driving `.github/scripts/build-zallet.sh` and `stage-zallet-db-dump.sh`
  from the reusable workflow behind an `is_zallet` input (this is what produces
  and stages the vendored `db_dump`).

## zizmor

Resolved the findings the analyzer raised on the new reusable workflow:

- `template-injection`: pass `inputs.default_ref` / `inputs.bin` through step
  `env` instead of interpolating them into the `run` script.
- `artipacked`: set `persist-credentials: false` on the source-repo checkout.
- `secrets-inherit`: pass `STATUS_APP_ID` / `STATUS_APP_PRIVATE_KEY` to the
  reusable workflow explicitly instead of `secrets: inherit`.
- `secrets-outside-env`: exempt `build-binary.yml` the same way `ci.yml`
  already is, since both hand those secrets straight to the interop composite
  action.