### PR TITLE
Run the RPC suite against both zallet backends (zaino + zebra)

### DIFF
--- a/.github/scripts/build-zallet.sh
+++ b/.github/scripts/build-zallet.sh
@@ -6,11 +6,12 @@
 # Zallet is structured as a thin `zallet` launcher (root workspace) that reads
 # the config's top-level `backend` key and execs a matching per-backend binary
 # (`zallet-zebra`, `zallet-zaino`), each built in its own workspace under
-# backends/. The integration RPC suite runs in regtest, which only the Zaino
-# backend supports, so we build the launcher plus `zallet-zaino`. Backend
-# selection is structural (which workspace binary is built, plus the config
-# `backend` key set in qa/defaults/zallet/zallet.toml), not a cargo feature, so
-# the zaino build takes no backend-selecting flags.
+# backends/. The integration RPC suite runs the same tests against both
+# backends, so we build the launcher plus BOTH `zallet-zaino` and
+# `zallet-zebra`. Backend selection is structural (which workspace binary the
+# launcher execs, driven by the config `backend` key the test framework writes
+# into qa/defaults/zallet/zallet.toml), not a cargo feature, so neither backend
+# build takes backend-selecting flags.
 #
 # The built binaries are copied into ./dist. When running under GitHub Actions,
 # DB_DUMP_ROOT is appended to $GITHUB_ENV naming the workspace build directory
@@ -32,14 +33,18 @@ zcashd_import="${ZCASHD_IMPORT:-}"
 dist=dist
 mkdir -p "$dist"
 
-# Launcher (root workspace) + Zaino backend binary (its own workspace).
+# Launcher (root workspace) + both backend binaries (each its own workspace).
 cargo build --release --target "$target" --bin zallet
 cargo build --release --target "$target" \
     --manifest-path backends/zaino/Cargo.toml \
     $zcashd_import --bin zallet-zaino
+cargo build --release --target "$target" \
+    --manifest-path backends/zebra/Cargo.toml \
+    $zcashd_import --bin zallet-zebra
 
 cp "target/$target/release/zallet$ext" "$dist/"
 cp "backends/zaino/target/$target/release/zallet-zaino$ext" "$dist/"
+cp "backends/zebra/target/$target/release/zallet-zebra$ext" "$dist/"
 
 if [ -n "${GITHUB_ENV:-}" ]; then
     echo "DB_DUMP_ROOT=backends/zaino/target/$target/release/build" >> "$GITHUB_ENV"

--- a/.github/scripts/make-zcash-artifacts-executable.sh
+++ b/.github/scripts/make-zcash-artifacts-executable.sh
@@ -2,8 +2,8 @@
 #
 # Make the zcash binaries downloaded into ./src executable on the test runners.
 #
-# The `zallet` launcher execs a sibling backend binary (`zallet-zaino`), so it is
-# made executable too when present.
+# The `zallet` launcher execs a sibling backend binary (`zallet-zaino` or
+# `zallet-zebra`), so those are made executable too when present.
 #
 # Inputs (environment):
 #   FILE_EXT  executable suffix, e.g. ".exe" (optional, default empty)
@@ -17,4 +17,7 @@ chmod +x "./src/zainod$ext"
 chmod +x "./src/zallet$ext"
 if [ -f "./src/zallet-zaino$ext" ]; then
     chmod +x "./src/zallet-zaino$ext"
+fi
+if [ -f "./src/zallet-zebra$ext" ]; then
+    chmod +x "./src/zallet-zebra$ext"
 fi

--- a/.github/workflows/build-binary.yml
+++ b/.github/workflows/build-binary.yml
@@ -1,7 +1,7 @@
 name: Build binary
 
 # Reusable workflow that builds a single binary (zebrad, zainod, or the zallet
-# launcher plus its zaino backend) for a given set of platforms. It is called
+# launcher plus its zaino and zebra backends) for a given set of platforms. It is called
 # twice per binary from `ci.yml`: once for the platforms the tests run on, and
 # once for the build-only platforms (macOS, Windows, cross-compiled targets).
 # Splitting the matrix this way lets the test jobs depend only on the builds
@@ -53,6 +53,14 @@ on:
         required: false
         type: boolean
         default: false
+      extra_build_args:
+        description: >-
+          Extra args appended to the `cargo build` invocation for the
+          non-zallet build path (e.g. "--features indexer" for zebrad). Ignored
+          when is_zallet is true.
+        required: false
+        type: string
+        default: ''
     secrets:
       STATUS_APP_ID:
         description: Status-reporting GitHub App ID (for interop requests).
@@ -227,17 +235,18 @@ jobs:
           key: ${{ matrix.name }}
           workspaces: "./${{ inputs.path }}"
 
-      - name: Cache cargo build (zallet launcher + zaino backend)
+      - name: Cache cargo build (zallet launcher + backends)
         if: ${{ inputs.is_zallet && steps.binary-cache.outputs.hit != 'true' }}
         uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
         with:
           key: ${{ matrix.name }}
-          # zallet is two workspaces: the root (the `zallet` launcher) and
-          # backends/zaino (the `zallet-zaino` backend binary), each with its
-          # own target directory. Cache both.
+          # zallet is three workspaces: the root (the `zallet` launcher),
+          # backends/zaino (`zallet-zaino`), and backends/zebra
+          # (`zallet-zebra`), each with its own target directory. Cache all.
           workspaces: |
             zallet
             zallet/backends/zaino
+            zallet/backends/zebra
 
       - name: Install Rust target
         if: steps.binary-cache.outputs.hit != 'true'
@@ -250,13 +259,15 @@ jobs:
           HOST: ${{ matrix.host }}
           CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: "aarch64-linux-gnu-gcc"
           BIN: ${{ inputs.bin }}
-        run: cargo build --release --target ${{ matrix.rust_target }} --bin "${BIN}"
+          EXTRA_BUILD_ARGS: ${{ inputs.extra_build_args }}
+        run: cargo build --release --target ${{ matrix.rust_target }} --bin "${BIN}" ${EXTRA_BUILD_ARGS}
         working-directory: ./${{ inputs.path }}
 
-      # Build the `zallet` launcher plus the `zallet-zaino` backend binary the
-      # regtest suite needs. See .github/scripts/build-zallet.sh. zcashd-import is
-      # disabled on mingw32: its pqcrypto-mlkem dep fails to cross-compile to
-      # windows-gnu, and the tests needing it are Linux-only.
+      # Build the `zallet` launcher plus the `zallet-zaino` and `zallet-zebra`
+      # backend binaries the regtest suite exercises. See
+      # .github/scripts/build-zallet.sh. zcashd-import is disabled on mingw32:
+      # its pqcrypto-mlkem dep fails to cross-compile to windows-gnu, and the
+      # tests needing it are Linux-only.
       - name: Build zallet
         if: ${{ inputs.is_zallet && steps.binary-cache.outputs.hit != 'true' }}
         env:
@@ -283,9 +294,10 @@ jobs:
           path: |
               ${{ format('./{0}/target/{1}/release/{2}{3}', inputs.path, matrix.rust_target, inputs.bin, matrix.file_ext) }}
 
-      # Upload the launcher, the Zaino backend binary, and the vendored db_dump.
-      # They land flat in ./src on the test runners; the launcher finds a sibling
-      # zallet-zaino next to itself.
+      # Upload the launcher, both backend binaries, and the vendored db_dump.
+      # They land flat in ./src on the test runners; the launcher finds the
+      # sibling zallet-zaino / zallet-zebra next to itself, selected by the
+      # config `backend` key.
       - name: Upload zallet
         if: ${{ inputs.is_zallet }}
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
@@ -294,6 +306,7 @@ jobs:
           path: |
               ${{ format('./zallet/dist/zallet{0}', matrix.file_ext) }}
               ${{ format('./zallet/dist/zallet-zaino{0}', matrix.file_ext) }}
+              ${{ format('./zallet/dist/zallet-zebra{0}', matrix.file_ext) }}
               ./zallet/dist/db_dump
           if-no-files-found: warn
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -347,6 +347,10 @@ jobs:
       path: zebra
       bin: zebrad
       job_name_prefix: Build zebrad on
+      # The zallet zebra backend follows zebrad's non-finalized tip over its
+      # gRPC indexer interface, which is gated behind the non-default `indexer`
+      # feature. Build it in for both backends (harmless to the zaino backend).
+      extra_build_args: --features indexer
 
   build-zebra-extra:
     needs: setup
@@ -367,6 +371,7 @@ jobs:
       path: zebra
       bin: zebrad
       job_name_prefix: Build zebrad on
+      extra_build_args: --features indexer
 
   build-zaino:
     needs: setup
@@ -574,7 +579,7 @@ jobs:
           pip install zmq asyncio base58 toml embit
 
   test-rpc:
-    name: RPC tests ${{ matrix.platform }} ${{ matrix.shard }}${{ matrix.required_suffix }}
+    name: RPC tests ${{ matrix.platform }} ${{ matrix.backend }} ${{ matrix.shard }}${{ matrix.required_suffix }}
     needs:
       - setup
       - build-zebra
@@ -591,6 +596,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # Run the same RPC suite against each zallet backend. The launcher execs
+        # the matching per-backend binary, selected by the ZALLET_BACKEND env var
+        # the test step exports (see the "RPC test" step). Both backends are
+        # required on the required platforms (no continue-on-error for zebra).
+        backend: [zaino, zebra]
         name: ${{ fromJson(needs.setup.outputs.rpc_test_names) }}
         shard : ${{ fromJson(needs.setup.outputs.rpc_test_shards) }}
         include: ${{ fromJson(needs.setup.outputs.rpc_test_shards_matrix) }}
@@ -624,7 +634,7 @@ jobs:
           status-app-private-key: ${{ secrets.STATUS_APP_PRIVATE_KEY }}
           requesting-owner: ${{ steps.repo-ids.outputs.requesting-owner }}
           requesting-repository: ${{ steps.repo-ids.outputs.requesting-repository }}
-          job-name: "RPC tests ${{ matrix.platform }} ${{ matrix.shard }}${{ matrix.required_suffix }}"
+          job-name: "RPC tests ${{ matrix.platform }} ${{ matrix.backend }} ${{ matrix.shard }}${{ matrix.required_suffix }}"
 
       - name: Set up Python
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
@@ -706,7 +716,7 @@ jobs:
             mv zcash-params "$HOME/.zcash-params"
           fi
 
-      - name: RPC test ${{ matrix.shard }}
+      - name: RPC test ${{ matrix.backend }} ${{ matrix.shard }}
         run: |
           cat <<EOF > ./subclass.py
           import importlib
@@ -735,7 +745,7 @@ jobs:
               sys.exit(1)
           EOF
           . ./venv/bin/activate
-          ZEBRAD=$(pwd)/${{ format('src/zebrad{0}', matrix.file_ext) }} ZAINOD=$(pwd)/${{ format('src/zainod{0}', matrix.file_ext) }} ZALLET=$(pwd)/${{ format('src/zallet{0}', matrix.file_ext) }} SRC_DIR=$(pwd) python3 ./subclass.py
+          ZALLET_BACKEND=${{ matrix.backend }} ZEBRAD=$(pwd)/${{ format('src/zebrad{0}', matrix.file_ext) }} ZAINOD=$(pwd)/${{ format('src/zainod{0}', matrix.file_ext) }} ZALLET=$(pwd)/${{ format('src/zallet{0}', matrix.file_ext) }} SRC_DIR=$(pwd) python3 ./subclass.py
 
       - uses: ./.github/actions/finish-interop
         if: always()
@@ -743,4 +753,4 @@ jobs:
           app-token: ${{ steps.start-interop.outputs.app-token }}
           requesting-owner: ${{ steps.repo-ids.outputs.requesting-owner }}
           requesting-repository: ${{ steps.repo-ids.outputs.requesting-repository }}
-          job-name: "RPC tests ${{ matrix.platform }} ${{ matrix.shard }}${{ matrix.required_suffix }}"
+          job-name: "RPC tests ${{ matrix.platform }} ${{ matrix.backend }} ${{ matrix.shard }}${{ matrix.required_suffix }}"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,13 +103,14 @@ Tested ecosystem projects:
 - [`zainod`](https://github.com/zingolabs/zaino) -- Zcash indexer
 - [`zallet`](https://github.com/zcash/zallet) -- Zcash wallet. Structured as a
   `zallet` launcher plus per-backend binaries (`zallet-zebra`, `zallet-zaino`),
-  each built in its own cargo workspace; these tests use the `zallet-zaino` backend.
+  each built in its own cargo workspace; CI runs the RPC suite against both
+  backends (see `ZALLET_BACKEND` below).
 
 ## Build, Test, and Development Commands
 
 ### Prerequisites
 
-Build `zebrad`, `zainod`, and `zallet` binaries and place them in a `./src/` directory under the repository root. `zallet` is a thin launcher that execs a per-backend binary; the tests run in regtest, which requires the Zaino backend, so also build `zallet-zaino` and place it in `./src/` next to the launcher (the launcher looks for the backend binary beside itself). The default config `qa/defaults/zallet/zallet.toml` selects it via its top-level `backend = "zaino"` key.
+Build `zebrad`, `zainod`, and `zallet` binaries and place them in a `./src/` directory under the repository root. `zallet` is a thin launcher that execs a per-backend binary, so also build the backend binaries (`zallet-zaino` and, to exercise the zebra backend, `zallet-zebra`) and place them in `./src/` next to the launcher (the launcher looks for the backend binary beside itself). The launcher selects the backend from the top-level `backend` key in `qa/defaults/zallet/zallet.toml` (default `zaino`); the test framework overrides it from the `ZALLET_BACKEND` environment variable (`zaino` or `zebra`), and CI runs the suite against both. The zebra backend also reads the co-located zebrad's state database directly and follows its gRPC indexer, so it requires a `zebrad` built with the (non-default) `indexer` feature.
 
 ### Running the test suite
 

--- a/README.md
+++ b/README.md
@@ -26,11 +26,14 @@ codebase, with the Python test framework (and some of the tests) inherited from
 - Clone the repository.
 - Build `zebrad`, `zainod`, and `zallet` binaries, and place them in a folder
   `./src/` under the repository root. `zallet` is a thin launcher that execs a
-  per-backend binary; the tests run in regtest, which needs the Zaino backend,
-  so also build `zallet-zaino` and place it in `./src/` alongside the launcher
-  (the launcher looks for the backend binary next to itself). The default config
-  in `qa/defaults/zallet/zallet.toml` selects the Zaino backend via its
-  top-level `backend` key.
+  per-backend binary, so also build the backend binaries (`zallet-zaino`, and
+  `zallet-zebra` to exercise the zebra backend) and place them in `./src/`
+  alongside the launcher (the launcher looks for the backend binary next to
+  itself). The launcher selects the backend from the top-level `backend` key in
+  `qa/defaults/zallet/zallet.toml` (default `zaino`); set `ZALLET_BACKEND=zebra`
+  to run the suite against the zebra backend instead. The zebra backend reads
+  the co-located zebrad's state database directly, so it needs a `zebrad` built
+  with the (non-default) `indexer` feature.
 
 #### With uv (recommended)
 

--- a/qa/defaults/zallet/zallet.toml
+++ b/qa/defaults/zallet/zallet.toml
@@ -1,7 +1,9 @@
 # The `zallet` launcher reads this top-level key and execs the matching backend
-# binary (here `zallet-zaino`). The integration suite runs in regtest, which the
-# default `zebra` backend does not support. Top-level keys must precede the first
-# table header.
+# binary (`zallet-zaino` or `zallet-zebra`). The test framework overrides this
+# key (and, for `zebra`, adds an [indexer.read_state_service] section) from the
+# ZALLET_BACKEND environment variable so the suite can run against either
+# backend; `zaino` is the default here for local runs. Top-level keys must
+# precede the first table header.
 backend = "zaino"
 
 [builder.limits]

--- a/qa/rpc-tests/test_framework/util.py
+++ b/qa/rpc-tests/test_framework/util.py
@@ -412,7 +412,9 @@ def initialize_chain(test_dir, num_nodes, cachedir, cache_behavior='current'):
         miner_addresses = {}
         for i in range(MAX_NODES):
             datadir = wallet_dir(cachedir, i)
-            update_zallet_conf(datadir, rpc_port(i), wallet_rpc_port(i))
+            update_zallet_conf(datadir, rpc_port(i), wallet_rpc_port(i),
+                               indexer_port=indexer_rpc_port(i),
+                               zebra_state_dir=node_dir(cachedir, i))
 
             args = [ zallet, "-d="+datadir, "init-wallet-encryption" ]
             process = subprocess.Popen(args)
@@ -1106,7 +1108,9 @@ def prepare_wallets_for_mining(num_wallets, dirname, binary=None, zallet_args=No
 
         zallet = binary[i]
 
-        update_zallet_conf(datadir, rpc_port(i), wallet_rpc_port(i), zallet_args[i])
+        update_zallet_conf(datadir, rpc_port(i), wallet_rpc_port(i), zallet_args[i],
+                           indexer_port=indexer_rpc_port(i),
+                           zebra_state_dir=node_dir(dirname, i))
 
         args = [ zallet, "-d="+datadir, "init-wallet-encryption" ]
         process = subprocess.Popen(args)
@@ -1154,7 +1158,9 @@ def start_wallet(i, dirname, extra_args=None, rpchost=None, timewait=None, binar
     validator_port = rpc_port(i)
     zallet_port = wallet_rpc_port(i)
 
-    update_zallet_conf(datadir, validator_port, zallet_port, zallet_args)
+    update_zallet_conf(datadir, validator_port, zallet_port, zallet_args,
+                       indexer_port=indexer_rpc_port(i),
+                       zebra_state_dir=node_dir(dirname, i))
 
     # We prepare the wallet if it is new
     if prepare:
@@ -1183,7 +1189,15 @@ def start_wallet(i, dirname, extra_args=None, rpchost=None, timewait=None, binar
 
     return proxy
 
-def update_zallet_conf(datadir, validator_port, zallet_port, extra_args=None):
+# The zallet backend the launcher execs (top-level `backend` key in
+# zallet.toml). CI sets this to run the same RPC suite against both the `zaino`
+# and `zebra` backends; it defaults to `zaino` to match the checked-in default
+# config and local runs.
+def zallet_backend():
+    return os.getenv("ZALLET_BACKEND", "zaino")
+
+def update_zallet_conf(datadir, validator_port, zallet_port, extra_args=None,
+                       indexer_port=None, zebra_state_dir=None):
     config_path = zallet_config(datadir)
 
     with open(config_path, "r", encoding="utf8") as f:
@@ -1191,6 +1205,24 @@ def update_zallet_conf(datadir, validator_port, zallet_port, extra_args=None):
 
     config_file['rpc']['bind'][0] = '127.0.0.1:'+str(zallet_port)
     config_file['indexer']['validator_address'] = '127.0.0.1:'+str(validator_port)
+
+    # Select the backend the launcher execs. The `zebra` backend does not talk
+    # to zainod; it opens the co-located zebrad's state database read-only and
+    # follows the tip over zebrad's gRPC indexer interface, so it needs an
+    # [indexer.read_state_service] section pointing at that zebrad. Both the
+    # indexer gRPC port and zebrad's state directory are required for it.
+    backend = zallet_backend()
+    config_file['backend'] = backend
+    if backend == "zebra":
+        assert indexer_port is not None and zebra_state_dir is not None, \
+            "the zebra backend requires indexer_port and zebra_state_dir"
+        config_file['indexer']['read_state_service'] = {
+            'grpc_address': '127.0.0.1:'+str(indexer_port),
+            'zebra_state_path': os.path.abspath(zebra_state_dir),
+        }
+    else:
+        # Never leave a stale zebra section behind when reusing a config file.
+        config_file['indexer'].pop('read_state_service', None)
 
     extra_args = extra_args or ZalletArgs()
 

--- a/qa/rpc-tests/test_framework/util.py
+++ b/qa/rpc-tests/test_framework/util.py
@@ -1458,6 +1458,17 @@ class Pool(str, Enum):
     IRONWOOD = 'ironwood'
 
 
+class TotalBalanceField(str, Enum):
+    """A summary field of `z_gettotalbalance`: the `transparent` pool, the
+    aggregate shielded balance (`private`), or their `total`. This is NOT a
+    `Pool`: `private`/`total` are roll-ups across pools, not value pools, so
+    they have no `Pool` member. Being `str`-valued, a member is usable directly
+    as the dict key into `z_gettotalbalance`'s output."""
+    TRANSPARENT = 'transparent'
+    PRIVATE = 'private'
+    TOTAL = 'total'
+
+
 class FundSource(str, Enum):
     """The `fund_source` selector accepted by z_sendfromaccount /
     z_proposetransaction, naming where an account's funds may be drawn from.
@@ -1665,8 +1676,11 @@ def wait_for_stable_mature_coinbase(wallet: RpcProxy, min_count: int = 1,
 def wait_for_tx_scanned(wallet: RpcProxy, txid: str, timeout: int = 120) -> dict:
     """
     Return `txid`'s `z_viewtransaction` view once it carries a `fee`, i.e. the
-    confirming block is scanned. Other scan-dependent views (balance,
-    z_listunspent) are then current too, so they can be read without a wait.
+    confirming block is scanned. Note this only guarantees the per-transaction
+    view is current: `z_gettotalbalance`'s summary is computed from a separate
+    internal scan tip that can still lag by a block, so poll it with
+    `wait_for_total_balance` rather than reading it once right after this
+    returns.
     """
     deadline = time.time() + timeout
     last_err = None
@@ -1681,6 +1695,37 @@ def wait_for_tx_scanned(wallet: RpcProxy, txid: str, timeout: int = 120) -> dict
     raise AssertionError(
         "wait_for_tx_scanned: timeout after {}s for txid {} ({})".format(
             timeout, txid, last_err))
+
+
+def wait_for_total_balance(wallet: RpcProxy, field: TotalBalanceField,
+                           predicate: Callable[[Decimal], bool],
+                           minconf: int = 1, include_watchonly: bool = True,
+                           timeout: int = 60) -> Decimal:
+    """
+    Poll `z_gettotalbalance(minconf, include_watchonly)` until `predicate`
+    holds for the `Decimal` value of `field` (a `TotalBalanceField`: the
+    transparent pool, the aggregate `private` balance, or the `total`), then
+    return that value. On timeout, return the last value read so the caller's
+    assertion can report it.
+
+    `z_gettotalbalance`'s summary is computed from an internal scan tip that can
+    lag `wallet_tip` (or a just-scanned transaction) by a block, so a single
+    read right after a `generate`/scan can miss the newest coinbase or note.
+    This rides out that lag; see zcash/wallet#316.
+    """
+    deadline = time.time() + timeout
+    last = None
+    while True:
+        try:
+            last = Decimal(
+                wallet.z_gettotalbalance(minconf, include_watchonly)[field])
+            if predicate(last):
+                return last
+        except Exception:
+            pass
+        if time.time() >= deadline:
+            return last
+        time.sleep(1)
 
 
 def wait_for_pool_note(wallet: RpcProxy, pool: Pool | str, minconf: int = 1,

--- a/qa/rpc-tests/wallet.py
+++ b/qa/rpc-tests/wallet.py
@@ -9,7 +9,13 @@
 from decimal import Decimal
 
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import assert_equal, assert_true, wait_for_wallet_sync
+from test_framework.util import (
+    TotalBalanceField,
+    assert_equal,
+    assert_true,
+    wait_for_total_balance,
+    wait_for_wallet_sync,
+)
 
 # Coinbase outputs require 100 confirmations before zallet counts them.
 COINBASE_MATURITY = 100
@@ -21,7 +27,8 @@ _SCAN_LAG_TOLERANCE = 5
 
 
 def _wallet_transparent_zec(wallet):
-    return Decimal(wallet.z_gettotalbalance(1, True)['transparent'])
+    return Decimal(
+        wallet.z_gettotalbalance(1, True)[TotalBalanceField.TRANSPARENT])
 
 
 # Test that we can create a wallet and use an address from it to mine blocks.
@@ -69,7 +76,12 @@ class WalletTest (BitcoinTestFramework):
         prev_zec = wallet_zec
         node.generate(1)
         wait_for_wallet_sync(node, wallet)
-        new_zec = _wallet_transparent_zec(wallet)
+        # wait_for_wallet_sync only guarantees wallet_tip has advanced;
+        # z_gettotalbalance's transparent summary uses an internal scan tip that
+        # can lag it by a block, so poll until the fresh coinbase surfaces
+        # rather than reading the balance once.
+        new_zec = wait_for_total_balance(
+            wallet, TotalBalanceField.TRANSPARENT, lambda v: v > prev_zec)
         assert_true(
             new_zec > prev_zec,
             "wallet transparent balance should grow after mining "

--- a/qa/rpc-tests/wallet_ironwood.py
+++ b/qa/rpc-tests/wallet_ironwood.py
@@ -42,6 +42,7 @@ from test_framework.util import (
     COIN,
     COINBASE_MATURITY,
     Pool,
+    TotalBalanceField,
     assert_equal,
     assert_true,
     nu_activation_all_at_1_with_ironwood,
@@ -50,6 +51,7 @@ from test_framework.util import (
     wait_and_assert_operationid_status,
     wait_for_account_spendable,
     wait_for_mature_coinbase_count,
+    wait_for_total_balance,
     wait_for_tx_scanned,
 )
 
@@ -125,10 +127,12 @@ class WalletIronwoodTest(BitcoinTestFramework):
         ironwood_zec = shielding_value - fee
 
         # The shielded value is counted as private (z_gettotalbalance sums the
-        # Ironwood pool into `private`). This holds as soon as the note is
-        # scanned, before it is spendable.
-        total = w.z_gettotalbalance(1, True)
-        assert_equal(Decimal(total['private']), ironwood_zec,
+        # Ironwood pool into `private`), once the note is scanned and before it
+        # is spendable. z_gettotalbalance's summary tip can lag the scanned tx
+        # by a block, so poll rather than reading once.
+        private_zec = wait_for_total_balance(
+            w, TotalBalanceField.PRIVATE, lambda v: v == ironwood_zec)
+        assert_equal(private_zec, ironwood_zec,
                      "Ironwood funds should be counted as private")
 
         # Wait for the Ironwood note to become spendable (the confirming block

--- a/qa/rpc-tests/wallet_z_shieldcoinbase.py
+++ b/qa/rpc-tests/wallet_z_shieldcoinbase.py
@@ -34,6 +34,7 @@ from test_framework.test_framework import BitcoinTestFramework
 from test_framework.config import ZebraArgs
 from test_framework.util import (
     COINBASE_MATURITY,
+    TotalBalanceField,
     assert_equal,
     assert_in_message,
     assert_shieldcoinbase_preflight_shape,
@@ -44,6 +45,7 @@ from test_framework.util import (
     wait_and_assert_operationid_status,
     wait_and_assert_operationid_status_result,
     wait_for_mature_coinbase_count,
+    wait_for_total_balance,
     wait_for_tx_scanned,
 )
 
@@ -254,14 +256,21 @@ class WalletZShieldCoinbaseTest(BitcoinTestFramework):
             node.generate(1)
             tx_details = wait_for_tx_scanned(w0, txid)
             fee = Decimal(tx_details['fee'])
-            post_private = Decimal(w0.z_gettotalbalance(1, True)['private'])
-            assert_equal(post_private, pre_private + shielding_value - fee)
+            expected_private = pre_private + shielding_value - fee
+            # wait_for_tx_scanned only proves the per-tx view is scanned; the
+            # 'private' figure from z_gettotalbalance uses a summary tip that can
+            # lag by a block, so poll until it reflects the shielded note rather
+            # than reading it once.
+            post_private = wait_for_total_balance(
+                w0, TotalBalanceField.PRIVATE, lambda v: v == expected_private)
+            assert_equal(post_private, expected_private)
             return fee, post_private, tx_details
 
         # ---- F1: explicit single-t-addr sweep -----------------------
 
         print("Test F1: explicit single-t-addr sweep (response shape + balance moves)...")
-        pre_private = Decimal(w0.z_gettotalbalance(1, True)['private'])
+        pre_private = Decimal(
+            w0.z_gettotalbalance(1, True)[TotalBalanceField.PRIVATE])
         n_expected = len(wait_for_mature_coinbase_count(w0, expected_unspent_mature()))
         print("  [diag] mature coinbase UTXO count={}".format(n_expected))
 
@@ -371,10 +380,13 @@ class WalletZShieldCoinbaseTest(BitcoinTestFramework):
         node.generate(1)
         fee1 = Decimal(wait_for_tx_scanned(w0, txid1)['fee'])
         fee2 = Decimal(wait_for_tx_scanned(w0, txid2)['fee'])
-        post_private = Decimal(w0.z_gettotalbalance(1, True)['private'])
-        assert_equal(
-            post_private,
+        expected_private = (
             pre_private + shielding_value1 + shielding_value2 - fee1 - fee2)
+        # As in confirm_and_check_balance, the 'private' summary can lag the
+        # scanned txs by a block, so poll rather than reading once.
+        post_private = wait_for_total_balance(
+            w0, TotalBalanceField.PRIVATE, lambda v: v == expected_private)
+        assert_equal(post_private, expected_private)
         mature_spent += n_eligible
         print("  PASSED ({}/{} selected, {} swept in follow-up)".format(
             limit, n_eligible, remaining_utxos1))

--- a/qa/rpc-tests/wallet_z_shieldcoinbase_multi_taddr.py
+++ b/qa/rpc-tests/wallet_z_shieldcoinbase_multi_taddr.py
@@ -46,6 +46,7 @@ from test_framework.config import ZebraArgs
 from test_framework.util import (
     COINBASE_MATURITY,
     COINBASE_SETTLE_SECS,
+    TotalBalanceField,
     assert_equal,
     assert_shieldcoinbase_preflight_shape,
     assert_true,
@@ -60,6 +61,8 @@ from test_framework.util import (
     stop_wallets,
     wait_and_assert_operationid_status,
     wait_bitcoinds,
+    wait_for_total_balance,
+    wait_for_tx_scanned,
     wait_zallets,
 )
 
@@ -272,32 +275,23 @@ class WalletZShieldCoinbaseMultiTaddrTest(BitcoinTestFramework):
         spent_b = (mature_b[0]['txid'], mature_b[0]['outindex'])
 
         # ---- Phase 6: confirm the sweep tx. ------------------------
-        # Wait for the balance to reach exactly shieldingValue - fee: this is
-        # both the sync barrier (confirming block fully scanned) and an exact
-        # assertion.
+        # Wait for the confirming block to be scanned (the tx view carries a
+        # fee), then poll the balance to reach exactly shieldingValue - fee.
+        # z_gettotalbalance's summary tip can lag the scanned tx by a block, so
+        # this is both the sync barrier and the exact assertion.
         node.generate(1)
         shielding_value = Decimal(result['shieldingValue'])
-        deadline = time.time() + 180
-        fee = None
-        post_private = Decimal('0')
-        while time.time() < deadline:
-            try:
-                tx_details = w0.z_viewtransaction(txid)
-                if 'fee' in tx_details:
-                    fee = Decimal(tx_details['fee'])
-                    post_private = Decimal(w0.z_gettotalbalance(1, True)['private'])
-                    if fee > 0 and post_private == shielding_value - fee:
-                        break
-            except Exception:
-                pass
-            time.sleep(1)
+        fee = Decimal(wait_for_tx_scanned(w0, txid)['fee'])
+        expected_private = shielding_value - fee
+        post_private = wait_for_total_balance(
+            w0, TotalBalanceField.PRIVATE, lambda v: v == expected_private)
 
         # ---- Phase 7: post-sweep assertions (exact). ---------------
-        assert_true(fee is not None and fee > 0,
+        assert_true(fee > 0,
                     "Sweep fee should be positive, got {}".format(fee))
         assert_equal(
             post_private,
-            shielding_value - fee,
+            expected_private,
             "Post-sweep shielded balance should equal shieldingValue ({}) - fee ({}); "
             "got {}".format(shielding_value, fee, post_private))
 

--- a/qa/zcash/full_test_suite.py
+++ b/qa/zcash/full_test_suite.py
@@ -59,6 +59,7 @@ RUST_BINARIES = [
     'src/zainod',
     'src/zallet',
     'src/zallet-zaino',
+    'src/zallet-zebra',
 ]
 
 def test_rpath_runpath(filename):
@@ -94,9 +95,9 @@ def check_security_hardening():
     # PIE, RELRO, Canary, and NX are tested by `contrib/devtools/security-check.py`.
     # `zallet` is the pure-Rust launcher: it has no C dependencies, so it carries no
     # stack-canary symbol and is checked with --allow-no-canary. The real wallet work
-    # runs in `zallet-zaino`, which links the C libraries (BDB, secp256k1) and is
-    # canary-checked in full.
-    bin_programs = ['src/zebrad', 'src/zainod', 'src/zallet-zaino']
+    # runs in the per-backend binaries (`zallet-zaino`, `zallet-zebra`), which link the
+    # C libraries (BDB, secp256k1) and are canary-checked in full.
+    bin_programs = ['src/zebrad', 'src/zainod', 'src/zallet-zaino', 'src/zallet-zebra']
     no_canary_programs = ['src/zallet']
     bin_scripts = []
 


### PR DESCRIPTION
Closes #152.

zallet is a launcher that execs a per-backend binary (`zallet-zaino` /
`zallet-zebra`), selected by the top-level `backend` key in its config. Until
now CI only built and exercised the `zaino` backend. This makes the same
regtest RPC suite run against **both** backends, both required.

## What changed

- **Build**: `build-zallet.sh` now also builds `backends/zebra --bin
  zallet-zebra`; `build-binary.yml` caches its workspace, uploads it in the
  zallet artifact next to the launcher, and `sec-hard` canary-checks it. A new
  `extra_build_args` input lets the reusable build workflow pass extra cargo
  flags.
- **zebrad indexer feature**: the zebra backend follows zebrad's non-finalized
  tip over its gRPC indexer interface, which is behind zebrad's non-default
  `indexer` feature, so zebrad is now built with `--features indexer` (harmless
  to the zaino backend).
- **Backend selection**: `update_zallet_conf` reads `ZALLET_BACKEND` (default
  `zaino`) and writes the launcher's `backend` key. For `zebra` it also writes
  an `[indexer.read_state_service]` section pointing at the co-located zebrad
  (grpc at the indexer port, `zebra_state_path` at the node's state dir), since
  that backend reads zebrad's state DB directly rather than talking to zainod.
- **CI matrix**: `test-rpc` gains a `backend: [zaino, zebra]` axis; both are
  required on the required platforms.

## Dependencies

- The zebra backend gaining regtest support is **zcash/zallet#569** (`backend:
  support regtest in the zebra read-state backends`). CI builds zallet from
  `zcash/zallet` main by default, so that PR must land (or be paired via a
  `ZIT-Revision:` interop request) for the zebra jobs to pass.
- Based on `dw/ironwood-support` (#155): these changes build on that branch's
  test-framework wiring in `util.py`. Rebase onto `main` once #155 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)