### PR TITLE
ci: cache built binaries per upstream commit to avoid rebuilds

### DIFF
--- a/.github/scripts/prune-binary-caches.sh
+++ b/.github/scripts/prune-binary-caches.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+#
+# Keep at most $KEEP GitHub Actions caches whose key starts with $PREFIX,
+# deleting the oldest beyond that. This bounds the per-binary, per-platform
+# build cache (see issue #156) to a small number of recent upstream versions,
+# so bouncing between a handful of upstream commits stays a cache hit while
+# stale versions are reclaimed instead of relying solely on GitHub's global
+# eviction.
+#
+# Run this before the cache created by the current job is saved (the actions/
+# cache post step runs later), so it counts only pre-existing caches. Keeping
+# $KEEP here means the steady state is $KEEP (plus at most the one this run is
+# about to add, pruned by the next run).
+#
+# Inputs (environment):
+#   GH_TOKEN  token with actions:write on $REPO (required; use github.token)
+#   REPO      owner/name of the repository (required)
+#   PREFIX    cache-key prefix to prune (required)
+#   KEEP      max number of caches to retain for the prefix (optional, default 5)
+
+set -euo pipefail
+
+repo="${REPO:?REPO must be set}"
+prefix="${PREFIX:?PREFIX must be set}"
+keep="${KEEP:-5}"
+
+# List caches newest-first (paginated), keep only those matching the prefix,
+# skip the newest $keep, and delete the rest by id. @tsv keeps id and key on a
+# single tab-separated line so a key can never be split on whitespace.
+gh api --paginate \
+  "repos/${repo}/actions/caches?per_page=100&sort=created_at&direction=desc" \
+  --jq '.actions_caches[] | [.id, .key] | @tsv' \
+  | awk -F '\t' -v p="$prefix" 'index($2, p) == 1 { print $1 }' \
+  | tail -n "+$((keep + 1))" \
+  | while read -r id; do
+      [ -n "$id" ] || continue
+      echo "Deleting old cache id=${id}"
+      gh api -X DELETE "repos/${repo}/actions/caches/${id}" >/dev/null
+    done

--- a/.github/workflows/build-binary.yml
+++ b/.github/workflows/build-binary.yml
@@ -7,6 +7,15 @@ name: Build binary
 # Splitting the matrix this way lets the test jobs depend only on the builds
 # they actually consume, instead of waiting for every platform to finish
 # building.
+#
+# The built binary is cached keyed by the upstream source commit (see issue
+# #156). The tested projects (zebrad, zainod, zallet) move much less often than
+# this repository, so most CI runs rebuild an identical upstream commit. We
+# resolve the upstream ref to a concrete commit SHA, restore a cache keyed by
+# it, and skip the whole build (and the source checkout) on a hit, only
+# rebuilding when the upstream commit actually changed. A post-build step prunes
+# the per-binary, per-platform caches to the most recent 5 versions, which is
+# why this workflow needs `actions: write`.
 
 on:
   workflow_call:
@@ -54,6 +63,9 @@ on:
 
 permissions:
   contents: read
+  # Needed by the "Prune old binary caches" step to delete stale caches via the
+  # Actions cache API. The calling jobs in ci.yml grant this per-job.
+  actions: write
 
 jobs:
   build:
@@ -102,7 +114,72 @@ jobs:
           DEFAULT_REF: ${{ inputs.default_ref }}
         run: echo "TARGET_REF=${DEFAULT_REF}" >> $GITHUB_ENV
 
+      # Resolve TARGET_REF to a concrete commit SHA. An interop request already
+      # pins a SHA; the default-branch case is a symbolic ref (refs/heads/...),
+      # which we resolve with `git ls-remote` against the source repository. The
+      # SHA is the cache key below, so the build is reused across integration-
+      # tests commits as long as the upstream commit is unchanged.
+      - name: Resolve upstream commit SHA
+        id: resolve-sha
+        shell: bash
+        env:
+          REPOSITORY: ${{ inputs.repository }}
+        run: |
+          case "${TARGET_REF}" in
+            refs/*)
+              sha=$(git ls-remote "https://github.com/${REPOSITORY}.git" \
+                "${TARGET_REF}" | cut -f1)
+              ;;
+            *)
+              sha="${TARGET_REF}"
+              ;;
+          esac
+          if [ -z "${sha}" ]; then
+            echo "Could not resolve ${REPOSITORY} ref ${TARGET_REF}" >&2
+            exit 1
+          fi
+          echo "Resolved ${REPOSITORY} ${TARGET_REF} to ${sha}"
+          echo "sha=${sha}" >> "$GITHUB_OUTPUT"
+
+      # Restore the cached binary for this exact upstream commit. The key mixes
+      # in a hash of the build inputs (this workflow and the zallet build
+      # scripts) so that changing how we build invalidates stale binaries even
+      # when the upstream commit is unchanged. Only one of the two steps runs,
+      # per is_zallet; the combined result is read from `binary-cache.hit`.
+      - name: Restore cached ${{ inputs.bin }} binary (single workspace)
+        id: binary-cache-single
+        if: ${{ !inputs.is_zallet }}
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ${{ format('./{0}/target/{1}/release/{2}{3}', inputs.path, matrix.rust_target, inputs.bin, matrix.file_ext) }}
+          key: binary-${{ inputs.bin }}-${{ matrix.name }}-${{ steps.resolve-sha.outputs.sha }}-${{ hashFiles('integration-tests/.github/workflows/build-binary.yml') }}
+
+      - name: Restore cached zallet binaries
+        id: binary-cache-zallet
+        if: ${{ inputs.is_zallet }}
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          # The launcher, the zaino backend binary, and the vendored db_dump all
+          # land in ./zallet/dist; cache the directory as a unit.
+          path: ./zallet/dist
+          key: binary-${{ inputs.bin }}-${{ matrix.name }}-${{ steps.resolve-sha.outputs.sha }}-${{ hashFiles('integration-tests/.github/workflows/build-binary.yml', 'integration-tests/.github/scripts/build-zallet.sh', 'integration-tests/.github/scripts/stage-zallet-db-dump.sh') }}
+
+      - name: Determine binary cache hit
+        id: binary-cache
+        shell: bash
+        env:
+          IS_ZALLET: ${{ inputs.is_zallet }}
+          SINGLE_HIT: ${{ steps.binary-cache-single.outputs.cache-hit }}
+          ZALLET_HIT: ${{ steps.binary-cache-zallet.outputs.cache-hit }}
+        run: |
+          if [ "${IS_ZALLET}" = "true" ]; then
+            echo "hit=${ZALLET_HIT}" >> "$GITHUB_OUTPUT"
+          else
+            echo "hit=${SINGLE_HIT}" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Check out ${{ inputs.repository }}
+        if: steps.binary-cache.outputs.hit != 'true'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: ${{ inputs.repository }}
@@ -111,25 +188,27 @@ jobs:
           persist-credentials: false
 
       - name: Install Homebrew build dependencies
-        if: matrix.brew_deps != ''
+        if: matrix.brew_deps != '' && steps.binary-cache.outputs.hit != 'true'
         run: brew install ${{ matrix.brew_deps }}
 
       - name: Install cross-compilation build dependencies
-        if: matrix.cross_deps != ''
+        if: matrix.cross_deps != '' && steps.binary-cache.outputs.hit != 'true'
         run: sudo apt update && sudo apt install ${{ matrix.cross_deps }}
 
       - name: Configure MinGW to use POSIX variant
-        if: matrix.name == 'mingw32'
+        if: matrix.name == 'mingw32' && steps.binary-cache.outputs.hit != 'true'
         run: |
           sudo update-alternatives --set x86_64-w64-mingw32-gcc $(update-alternatives --query x86_64-w64-mingw32-gcc | grep Alternative | grep posix | cut -d' ' -f2)
           sudo update-alternatives --set x86_64-w64-mingw32-g++ $(update-alternatives --query x86_64-w64-mingw32-g++ | grep Alternative | grep posix | cut -d' ' -f2)
 
       - name: Prepare ccache timestamp
         id: ccache_cache_timestamp
+        if: steps.binary-cache.outputs.hit != 'true'
         shell: bash
         run: echo "timestamp=$(date +'%Y-%m-%d-%H;%M;%S')" >> "$GITHUB_OUTPUT"
 
       - name: Cache ccache files
+        if: steps.binary-cache.outputs.hit != 'true'
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ${{ runner.os == 'macOS' && '~/Library/Caches/ccache' || '~/.cache/ccache' }}
@@ -138,14 +217,14 @@ jobs:
             ${{ matrix.name }}-ccache-
 
       - name: Cache cargo build (single workspace)
-        if: ${{ !inputs.is_zallet }}
+        if: ${{ !inputs.is_zallet && steps.binary-cache.outputs.hit != 'true' }}
         uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
         with:
           key: ${{ matrix.name }}
           workspaces: "./${{ inputs.path }}"
 
       - name: Cache cargo build (zallet launcher + zaino backend)
-        if: ${{ inputs.is_zallet }}
+        if: ${{ inputs.is_zallet && steps.binary-cache.outputs.hit != 'true' }}
         uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
         with:
           key: ${{ matrix.name }}
@@ -157,11 +236,12 @@ jobs:
             zallet/backends/zaino
 
       - name: Install Rust target
+        if: steps.binary-cache.outputs.hit != 'true'
         run: rustup target add ${{ matrix.rust_target }}
         working-directory: ./${{ inputs.path }}
 
       - name: Build ${{ inputs.bin }}
-        if: ${{ !inputs.is_zallet }}
+        if: ${{ !inputs.is_zallet && steps.binary-cache.outputs.hit != 'true' }}
         env:
           HOST: ${{ matrix.host }}
           CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: "aarch64-linux-gnu-gcc"
@@ -174,7 +254,7 @@ jobs:
       # disabled on mingw32: its pqcrypto-mlkem dep fails to cross-compile to
       # windows-gnu, and the tests needing it are Linux-only.
       - name: Build zallet
-        if: ${{ inputs.is_zallet }}
+        if: ${{ inputs.is_zallet && steps.binary-cache.outputs.hit != 'true' }}
         env:
           HOST: ${{ matrix.host }}
           CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: "aarch64-linux-gnu-gcc"
@@ -186,7 +266,7 @@ jobs:
         run: "${{ github.workspace }}/integration-tests/.github/scripts/build-zallet.sh"
 
       - name: Stage vendored db_dump
-        if: ${{ inputs.is_zallet && matrix.name != 'mingw32' && runner.os != 'Windows' }}
+        if: ${{ inputs.is_zallet && matrix.name != 'mingw32' && runner.os != 'Windows' && steps.binary-cache.outputs.hit != 'true' }}
         shell: bash
         working-directory: ./zallet
         run: "${{ github.workspace }}/integration-tests/.github/scripts/stage-zallet-db-dump.sh"
@@ -212,6 +292,20 @@ jobs:
               ${{ format('./zallet/dist/zallet-zaino{0}', matrix.file_ext) }}
               ./zallet/dist/db_dump
           if-no-files-found: warn
+
+      # Bound the cache to the 5 most recent upstream versions for this binary
+      # and platform (issue #156), deleting older ones. Best-effort: a failure
+      # here (e.g. a read-only token on a fork PR) must not fail the build.
+      - name: Prune old ${{ inputs.bin }} binary caches
+        if: steps.binary-cache.outputs.hit != 'true'
+        continue-on-error: true
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PREFIX: binary-${{ inputs.bin }}-${{ matrix.name }}-
+          KEEP: "5"
+        run: "${{ github.workspace }}/integration-tests/.github/scripts/prune-binary-caches.sh"
 
       - uses: ./integration-tests/.github/actions/finish-interop
         if: always()

--- a/.github/workflows/build-binary.yml
+++ b/.github/workflows/build-binary.yml
@@ -183,7 +183,11 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: ${{ inputs.repository }}
-          ref: ${{ env.TARGET_REF }}
+          # Check out the SHA resolved above, not the symbolic TARGET_REF: the
+          # cache key is that SHA, so building anything else (e.g. if the branch
+          # head moves between resolution and checkout) would store a binary
+          # under a key that misrepresents its contents.
+          ref: ${{ steps.resolve-sha.outputs.sha }}
           path: ${{ inputs.path }}
           persist-credentials: false
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -331,6 +331,10 @@ jobs:
   build-zebra:
     needs: setup
     if: ${{ needs.setup.outputs.test_build_matrix != '[]' }}
+    # actions: write lets build-binary.yml prune old binary caches (issue #156).
+    permissions:
+      contents: read
+      actions: write
     uses: ./.github/workflows/build-binary.yml
     secrets:
       STATUS_APP_ID: ${{ secrets.STATUS_APP_ID }}
@@ -347,6 +351,10 @@ jobs:
   build-zebra-extra:
     needs: setup
     if: ${{ needs.setup.outputs.extra_build_matrix != '[]' }}
+    # actions: write lets build-binary.yml prune old binary caches (issue #156).
+    permissions:
+      contents: read
+      actions: write
     uses: ./.github/workflows/build-binary.yml
     secrets:
       STATUS_APP_ID: ${{ secrets.STATUS_APP_ID }}
@@ -363,6 +371,10 @@ jobs:
   build-zaino:
     needs: setup
     if: ${{ needs.setup.outputs.test_build_matrix != '[]' }}
+    # actions: write lets build-binary.yml prune old binary caches (issue #156).
+    permissions:
+      contents: read
+      actions: write
     uses: ./.github/workflows/build-binary.yml
     secrets:
       STATUS_APP_ID: ${{ secrets.STATUS_APP_ID }}
@@ -379,6 +391,10 @@ jobs:
   build-zaino-extra:
     needs: setup
     if: ${{ needs.setup.outputs.extra_build_matrix != '[]' }}
+    # actions: write lets build-binary.yml prune old binary caches (issue #156).
+    permissions:
+      contents: read
+      actions: write
     uses: ./.github/workflows/build-binary.yml
     secrets:
       STATUS_APP_ID: ${{ secrets.STATUS_APP_ID }}
@@ -395,6 +411,10 @@ jobs:
   build-zallet:
     needs: setup
     if: ${{ needs.setup.outputs.test_build_matrix != '[]' }}
+    # actions: write lets build-binary.yml prune old binary caches (issue #156).
+    permissions:
+      contents: read
+      actions: write
     uses: ./.github/workflows/build-binary.yml
     secrets:
       STATUS_APP_ID: ${{ secrets.STATUS_APP_ID }}
@@ -412,6 +432,10 @@ jobs:
   build-zallet-extra:
     needs: setup
     if: ${{ needs.setup.outputs.extra_build_matrix != '[]' }}
+    # actions: write lets build-binary.yml prune old binary caches (issue #156).
+    permissions:
+      contents: read
+      actions: write
     uses: ./.github/workflows/build-binary.yml
     secrets:
       STATUS_APP_ID: ${{ secrets.STATUS_APP_ID }}

--- a/doc/book/src/ci/README.md
+++ b/doc/book/src/ci/README.md
@@ -32,6 +32,17 @@ required platforms to manage CI costs. When CI is triggered via cross-repo
 dispatch, callers may specify which platforms to run; all explicitly requested
 platforms are treated as required.
 
+## Build caching
+
+The tested projects move much less often than this repository, so most CI runs
+would otherwise rebuild an identical upstream commit. Each build resolves its
+upstream ref to a concrete commit SHA and restores a cache of the built binary
+keyed by that SHA (plus a hash of the build scripts). On a cache hit the source
+checkout and the `cargo build` are skipped entirely, and only the cached binary
+is uploaded as the artifact; the binary is rebuilt only when the upstream commit
+(or the build logic) actually changes. A best-effort post-build step prunes each
+per-binary, per-platform cache to its 5 most recent versions.
+
 ## Cross-repository integration
 
 External repositories can trigger integration tests from their PRs and receive


### PR DESCRIPTION
## Summary

Closes #156.

For every integration-tests commit, CI rebuilds zebrad, zainod, and zallet
from their upstream default branches. The tested projects move much less
often than this repository, so most runs rebuild an identical upstream
commit, which is wasted work.

## What changed

- `.github/workflows/build-binary.yml`: resolve each build's upstream ref to
  a concrete commit SHA (an interop request already pins one; the
  default-branch case is resolved with `git ls-remote`), and restore an
  `actions/cache` of the built binary keyed by that SHA plus a hash of the
  build inputs. On a cache hit the source checkout and the cargo build are
  skipped and the cached binary is uploaded as the artifact; the binary is
  rebuilt only when the upstream commit (or the build logic) changes.
- `.github/scripts/prune-binary-caches.sh` (new): best-effort prune keeping
  the 5 most recent versions per binary+platform, via the Actions cache API.
- `.github/workflows/ci.yml`: grant the reusable workflow `actions: write` on
  the build jobs so pruning can run.
- `doc/book/src/ci/README.md`: document the caching mechanism.

## Testing

- Shell lint (`test/lint/lint-shell.sh`), whitespace lint, `bash -n`, and YAML
  parse all pass.
- `actionlint` was not available in the environment, so GitHub Actions
  expression validity is by manual review, not a linter. Recommend watching
  the first CI run to confirm a cold miss builds+caches and a re-run hits.

## Notes for review

- "max 5" is a steady-state bound: pruning runs before `actions/cache` saves
  this run's entry, so the count can momentarily be 6 before the next run
  trims it.
- On fork PRs the `GITHUB_TOKEN` is read-only regardless of the `permissions`
  block, so pruning no-ops there (`continue-on-error`); caching still degrades
  gracefully to a plain build.
- Effectiveness relies on GitHub's cache scoping: pushes to `main` (and
  interop dispatches, which run on `main`) populate caches that PRs restore.