### PR TITLE
ci: fix zallet interop repo id after wallet→zallet rename

### DIFF
--- a/.github/actions/interop-repo-ids/action.yml
+++ b/.github/actions/interop-repo-ids/action.yml
@@ -22,7 +22,7 @@ runs:
           ) }}
         REQUESTING_REPO: |-
           ${{ case(
-            github.event.action == 'zallet-interop-request', 'wallet',
+            github.event.action == 'zallet-interop-request', 'zallet',
             github.event.action == 'zebra-interop-request', 'zebra',
             github.event.action == 'zaino-interop-request', 'zaino',
             null


### PR DESCRIPTION
The `zcash/wallet` repo was renamed to `zcash/zallet`, but `interop-repo-ids` still maps `zallet-interop-request` to the `wallet` repo. The App-token step then looks up `repos/zcash/wallet/installation`, which 404s, and every `zallet-interop-request` run aborts in the **Define CI matrix** job before building anything.

Fix: map `zallet-interop-request` to the `zallet` repo (owner `zcash` is unchanged).

Verified from the failing run: the token step errors with `Failed to create token for "wallet": Not Found — repos/zcash/wallet/installation (404)`. This also unblocks the `ZIT-Revision` interop run for zcash/zallet#581 / #76.

🤖 Generated with [Claude Code](https://claude.com/claude-code)