### PR TITLE
test framework: replace status magic strings with enums

### DIFF
--- a/qa/rpc-tests/feature_nu6.py
+++ b/qa/rpc-tests/feature_nu6.py
@@ -8,7 +8,7 @@ from decimal import Decimal
 from test_framework.config import ZebraArgs
 
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import assert_equal, start_nodes
+from test_framework.util import UpgradeStatus, assert_equal, start_nodes
 
 # Check the behaviour of the value pools and funding streams at NU6.
 #
@@ -88,13 +88,13 @@ class PoolsTest(BitcoinTestFramework):
         # Check the network upgrades are all pending
         (overwinter, sapling, blossom, heartwood, canopy, nu5, nu6) = get_network_upgrades(getblockchaininfo)
 
-        assert_equal(overwinter['status'], 'pending')
-        assert_equal(sapling['status'], 'pending')
-        assert_equal(blossom['status'], 'pending')
-        assert_equal(heartwood['status'], 'pending')
-        assert_equal(canopy['status'], 'pending')
-        assert_equal(nu5['status'], 'pending')
-        assert_equal(nu6['status'], 'pending')
+        assert_equal(overwinter['status'], UpgradeStatus.PENDING)
+        assert_equal(sapling['status'], UpgradeStatus.PENDING)
+        assert_equal(blossom['status'], UpgradeStatus.PENDING)
+        assert_equal(heartwood['status'], UpgradeStatus.PENDING)
+        assert_equal(canopy['status'], UpgradeStatus.PENDING)
+        assert_equal(nu5['status'], UpgradeStatus.PENDING)
+        assert_equal(nu6['status'], UpgradeStatus.PENDING)
 
         print("Activating Overwinter, Sapling, Blossom, Heartwood and Canopy at Block 1")
         self.nodes[0].generate(1)
@@ -118,13 +118,13 @@ class PoolsTest(BitcoinTestFramework):
         # Check the network upgrades up to Canopy are active
         (overwinter, sapling, blossom, heartwood, canopy, nu5, nu6) = get_network_upgrades(getblockchaininfo)
 
-        assert_equal(overwinter['status'], 'active')
-        assert_equal(sapling['status'], 'active')
-        assert_equal(blossom['status'], 'active')
-        assert_equal(heartwood['status'], 'active')
-        assert_equal(canopy['status'], 'active')
-        assert_equal(nu5['status'], 'pending')
-        assert_equal(nu6['status'], 'pending')
+        assert_equal(overwinter['status'], UpgradeStatus.ACTIVE)
+        assert_equal(sapling['status'], UpgradeStatus.ACTIVE)
+        assert_equal(blossom['status'], UpgradeStatus.ACTIVE)
+        assert_equal(heartwood['status'], UpgradeStatus.ACTIVE)
+        assert_equal(canopy['status'], UpgradeStatus.ACTIVE)
+        assert_equal(nu5['status'], UpgradeStatus.PENDING)
+        assert_equal(nu6['status'], UpgradeStatus.PENDING)
 
         print("Activating NU5 at Block 7")
         self.nodes[0].generate(6)
@@ -147,13 +147,13 @@ class PoolsTest(BitcoinTestFramework):
         # Check that NU5 is now active
         (overwinter, sapling, blossom, heartwood, canopy, nu5, nu6) = get_network_upgrades(getblockchaininfo)
 
-        assert_equal(overwinter['status'], 'active')
-        assert_equal(sapling['status'], 'active')
-        assert_equal(blossom['status'], 'active')
-        assert_equal(heartwood['status'], 'active')
-        assert_equal(canopy['status'], 'active')
-        assert_equal(nu5['status'], 'active')
-        assert_equal(nu6['status'], 'pending')
+        assert_equal(overwinter['status'], UpgradeStatus.ACTIVE)
+        assert_equal(sapling['status'], UpgradeStatus.ACTIVE)
+        assert_equal(blossom['status'], UpgradeStatus.ACTIVE)
+        assert_equal(heartwood['status'], UpgradeStatus.ACTIVE)
+        assert_equal(canopy['status'], UpgradeStatus.ACTIVE)
+        assert_equal(nu5['status'], UpgradeStatus.ACTIVE)
+        assert_equal(nu6['status'], UpgradeStatus.PENDING)
     
         # Check we have fundingstream rewards but no lockbox rewards yet
         fs_outputs = Decimal('1.25')
@@ -187,13 +187,13 @@ class PoolsTest(BitcoinTestFramework):
         # Check all upgrades up to NU6 are active
         (overwinter, sapling, blossom, heartwood, canopy, nu5, nu6) = get_network_upgrades(getblockchaininfo)
 
-        assert_equal(overwinter['status'], 'active')
-        assert_equal(sapling['status'], 'active')
-        assert_equal(blossom['status'], 'active')
-        assert_equal(heartwood['status'], 'active')
-        assert_equal(canopy['status'], 'active')
-        assert_equal(nu5['status'], 'active')
-        assert_equal(nu6['status'], 'active')
+        assert_equal(overwinter['status'], UpgradeStatus.ACTIVE)
+        assert_equal(sapling['status'], UpgradeStatus.ACTIVE)
+        assert_equal(blossom['status'], UpgradeStatus.ACTIVE)
+        assert_equal(heartwood['status'], UpgradeStatus.ACTIVE)
+        assert_equal(canopy['status'], UpgradeStatus.ACTIVE)
+        assert_equal(nu5['status'], UpgradeStatus.ACTIVE)
+        assert_equal(nu6['status'], UpgradeStatus.ACTIVE)
 
         # Check that we have fundingstreams and lockbox rewards
         fs_outputs = Decimal('0.5')

--- a/qa/rpc-tests/nuparams.py
+++ b/qa/rpc-tests/nuparams.py
@@ -6,6 +6,7 @@
 from test_framework.config import ZebraArgs
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
+    UpgradeStatus,
     assert_equal,
     start_nodes,
     nustr,
@@ -50,37 +51,37 @@ class NuparamsTest(BitcoinTestFramework):
         overwinter = upgrades[nustr(OVERWINTER_BRANCH_ID)]
         assert_equal(overwinter['name'], 'Overwinter')
         assert_equal(overwinter['activationheight'], 1)
-        assert_equal(overwinter['status'], 'pending')
+        assert_equal(overwinter['status'], UpgradeStatus.PENDING)
 
         sapling = upgrades[nustr(SAPLING_BRANCH_ID)]
         assert_equal(sapling['name'], 'Sapling')
         assert_equal(sapling['activationheight'], 1)
-        assert_equal(sapling['status'], 'pending')
+        assert_equal(sapling['status'], UpgradeStatus.PENDING)
 
         blossom = upgrades[nustr(BLOSSOM_BRANCH_ID)]
         assert_equal(blossom['name'], 'Blossom')
         assert_equal(blossom['activationheight'], 1)
-        assert_equal(blossom['status'], 'pending')
+        assert_equal(blossom['status'], UpgradeStatus.PENDING)
 
         heartwood = upgrades[nustr(HEARTWOOD_BRANCH_ID)]
         assert_equal(heartwood['name'], 'Heartwood')
         assert_equal(heartwood['activationheight'], 1)
-        assert_equal(heartwood['status'], 'pending')
+        assert_equal(heartwood['status'], UpgradeStatus.PENDING)
 
         canopy = upgrades[nustr(CANOPY_BRANCH_ID)]
         assert_equal(canopy['name'], 'Canopy')
         assert_equal(canopy['activationheight'], 1)
-        assert_equal(canopy['status'], 'pending')
+        assert_equal(canopy['status'], UpgradeStatus.PENDING)
 
         nu5 = upgrades[nustr(NU5_BRANCH_ID)]
         assert_equal(nu5['name'], 'NU5')
         assert_equal(nu5['activationheight'], 7)
-        assert_equal(nu5['status'], 'pending')
+        assert_equal(nu5['status'], UpgradeStatus.PENDING)
 
         nu6 = upgrades[nustr(NU6_BRANCH_ID)]
         assert_equal(nu6['name'], 'NU6')
         assert_equal(nu6['activationheight'], 9)
-        assert_equal(nu6['status'], 'pending')
+        assert_equal(nu6['status'], UpgradeStatus.PENDING)
 
         # Initial subsidy at the genesis block is 12.5 ZEC
         assert_equal(node.getblocksubsidy()["totalblocksubsidy"], Decimal("12.5"))
@@ -96,37 +97,37 @@ class NuparamsTest(BitcoinTestFramework):
         overwinter = upgrades[nustr(OVERWINTER_BRANCH_ID)]
         assert_equal(overwinter['name'], 'Overwinter')
         assert_equal(overwinter['activationheight'], 1)
-        assert_equal(overwinter['status'], 'active')
+        assert_equal(overwinter['status'], UpgradeStatus.ACTIVE)
 
         sapling = upgrades[nustr(SAPLING_BRANCH_ID)]
         assert_equal(sapling['name'], 'Sapling')
         assert_equal(sapling['activationheight'], 1)
-        assert_equal(sapling['status'], 'active')
+        assert_equal(sapling['status'], UpgradeStatus.ACTIVE)
 
         blossom = upgrades[nustr(BLOSSOM_BRANCH_ID)]
         assert_equal(blossom['name'], 'Blossom')
         assert_equal(blossom['activationheight'], 1)
-        assert_equal(blossom['status'], 'active')
+        assert_equal(blossom['status'], UpgradeStatus.ACTIVE)
 
         heartwood = upgrades[nustr(HEARTWOOD_BRANCH_ID)]
         assert_equal(heartwood['name'], 'Heartwood')
         assert_equal(heartwood['activationheight'], 1)
-        assert_equal(heartwood['status'], 'active')
+        assert_equal(heartwood['status'], UpgradeStatus.ACTIVE)
 
         canopy = upgrades[nustr(CANOPY_BRANCH_ID)]
         assert_equal(canopy['name'], 'Canopy')
         assert_equal(canopy['activationheight'], 1)
-        assert_equal(canopy['status'], 'active')
+        assert_equal(canopy['status'], UpgradeStatus.ACTIVE)
 
         nu5 = upgrades[nustr(NU5_BRANCH_ID)]
         assert_equal(nu5['name'], 'NU5')
         assert_equal(nu5['activationheight'], 7)
-        assert_equal(nu5['status'], 'pending')
+        assert_equal(nu5['status'], UpgradeStatus.PENDING)
 
         nu6 = upgrades[nustr(NU6_BRANCH_ID)]
         assert_equal(nu6['name'], 'NU6')
         assert_equal(nu6['activationheight'], 9)
-        assert_equal(nu6['status'], 'pending')
+        assert_equal(nu6['status'], UpgradeStatus.PENDING)
 
         # Block subsidy halves at Blossom due to block time halving
         # The founders' reward ends at Canopy and there are no funding streams
@@ -143,37 +144,37 @@ class NuparamsTest(BitcoinTestFramework):
         overwinter = upgrades[nustr(OVERWINTER_BRANCH_ID)]
         assert_equal(overwinter['name'], 'Overwinter')
         assert_equal(overwinter['activationheight'], 1)
-        assert_equal(overwinter['status'], 'active')
+        assert_equal(overwinter['status'], UpgradeStatus.ACTIVE)
 
         sapling = upgrades[nustr(SAPLING_BRANCH_ID)]
         assert_equal(sapling['name'], 'Sapling')
         assert_equal(sapling['activationheight'], 1)
-        assert_equal(sapling['status'], 'active')
+        assert_equal(sapling['status'], UpgradeStatus.ACTIVE)
 
         blossom = upgrades[nustr(BLOSSOM_BRANCH_ID)]
         assert_equal(blossom['name'], 'Blossom')
         assert_equal(blossom['activationheight'], 1)
-        assert_equal(blossom['status'], 'active')
+        assert_equal(blossom['status'], UpgradeStatus.ACTIVE)
 
         heartwood = upgrades[nustr(HEARTWOOD_BRANCH_ID)]
         assert_equal(heartwood['name'], 'Heartwood')
         assert_equal(heartwood['activationheight'], 1)
-        assert_equal(heartwood['status'], 'active')
+        assert_equal(heartwood['status'], UpgradeStatus.ACTIVE)
 
         canopy = upgrades[nustr(CANOPY_BRANCH_ID)]
         assert_equal(canopy['name'], 'Canopy')
         assert_equal(canopy['activationheight'], 1)
-        assert_equal(canopy['status'], 'active')
+        assert_equal(canopy['status'], UpgradeStatus.ACTIVE)
 
         nu5 = upgrades[nustr(NU5_BRANCH_ID)]
         assert_equal(nu5['name'], 'NU5')
         assert_equal(nu5['activationheight'], 7)
-        assert_equal(nu5['status'], 'active')
+        assert_equal(nu5['status'], UpgradeStatus.ACTIVE)
 
         nu6 = upgrades[nustr(NU6_BRANCH_ID)]
         assert_equal(nu6['name'], 'NU6')
         assert_equal(nu6['activationheight'], 9)
-        assert_equal(nu6['status'], 'pending')
+        assert_equal(nu6['status'], UpgradeStatus.PENDING)
 
         # Block subsidy remains the same after NU5
         assert_equal(node.getblocksubsidy()["totalblocksubsidy"], Decimal("6.25"))
@@ -187,37 +188,37 @@ class NuparamsTest(BitcoinTestFramework):
         overwinter = upgrades[nustr(OVERWINTER_BRANCH_ID)]
         assert_equal(overwinter['name'], 'Overwinter')
         assert_equal(overwinter['activationheight'], 1)
-        assert_equal(overwinter['status'], 'active')
+        assert_equal(overwinter['status'], UpgradeStatus.ACTIVE)
 
         sapling = upgrades[nustr(SAPLING_BRANCH_ID)]
         assert_equal(sapling['name'], 'Sapling')
         assert_equal(sapling['activationheight'], 1)
-        assert_equal(sapling['status'], 'active')
+        assert_equal(sapling['status'], UpgradeStatus.ACTIVE)
 
         blossom = upgrades[nustr(BLOSSOM_BRANCH_ID)]
         assert_equal(blossom['name'], 'Blossom')
         assert_equal(blossom['activationheight'], 1)
-        assert_equal(blossom['status'], 'active')
+        assert_equal(blossom['status'], UpgradeStatus.ACTIVE)
 
         heartwood = upgrades[nustr(HEARTWOOD_BRANCH_ID)]
         assert_equal(heartwood['name'], 'Heartwood')
         assert_equal(heartwood['activationheight'], 1)
-        assert_equal(heartwood['status'], 'active')
+        assert_equal(heartwood['status'], UpgradeStatus.ACTIVE)
 
         canopy = upgrades[nustr(CANOPY_BRANCH_ID)]
         assert_equal(canopy['name'], 'Canopy')
         assert_equal(canopy['activationheight'], 1)
-        assert_equal(canopy['status'], 'active')
+        assert_equal(canopy['status'], UpgradeStatus.ACTIVE)
 
         nu5 = upgrades[nustr(NU5_BRANCH_ID)]
         assert_equal(nu5['name'], 'NU5')
         assert_equal(nu5['activationheight'], 7)
-        assert_equal(nu5['status'], 'active')
+        assert_equal(nu5['status'], UpgradeStatus.ACTIVE)
 
         nu6 = upgrades[nustr(NU6_BRANCH_ID)]
         assert_equal(nu6['name'], 'NU6')
         assert_equal(nu6['activationheight'], 9)
-        assert_equal(nu6['status'], 'active')
+        assert_equal(nu6['status'], UpgradeStatus.ACTIVE)
 
         # Block subsidy remains the same after NU6
         assert_equal(node.getblocksubsidy()["totalblocksubsidy"], Decimal("6.25"))
@@ -231,42 +232,42 @@ class NuparamsTest(BitcoinTestFramework):
         overwinter = upgrades[nustr(OVERWINTER_BRANCH_ID)]
         assert_equal(overwinter['name'], 'Overwinter')
         assert_equal(overwinter['activationheight'], 1)
-        assert_equal(overwinter['status'], 'active')
+        assert_equal(overwinter['status'], UpgradeStatus.ACTIVE)
 
         sapling = upgrades[nustr(SAPLING_BRANCH_ID)]
         assert_equal(sapling['name'], 'Sapling')
         assert_equal(sapling['activationheight'], 1)
-        assert_equal(sapling['status'], 'active')
+        assert_equal(sapling['status'], UpgradeStatus.ACTIVE)
 
         blossom = upgrades[nustr(BLOSSOM_BRANCH_ID)]
         assert_equal(blossom['name'], 'Blossom')
         assert_equal(blossom['activationheight'], 1)
-        assert_equal(blossom['status'], 'active')
+        assert_equal(blossom['status'], UpgradeStatus.ACTIVE)
 
         heartwood = upgrades[nustr(HEARTWOOD_BRANCH_ID)]
         assert_equal(heartwood['name'], 'Heartwood')
         assert_equal(heartwood['activationheight'], 1)
-        assert_equal(heartwood['status'], 'active')
+        assert_equal(heartwood['status'], UpgradeStatus.ACTIVE)
 
         canopy = upgrades[nustr(CANOPY_BRANCH_ID)]
         assert_equal(canopy['name'], 'Canopy')
         assert_equal(canopy['activationheight'], 1)
-        assert_equal(canopy['status'], 'active')
+        assert_equal(canopy['status'], UpgradeStatus.ACTIVE)
 
         nu5 = upgrades[nustr(NU5_BRANCH_ID)]
         assert_equal(nu5['name'], 'NU5')
         assert_equal(nu5['activationheight'], 7)
-        assert_equal(nu5['status'], 'active')
+        assert_equal(nu5['status'], UpgradeStatus.ACTIVE)
 
         nu6 = upgrades[nustr(NU6_BRANCH_ID)]
         assert_equal(nu6['name'], 'NU6')
         assert_equal(nu6['activationheight'], 9)
-        assert_equal(nu6['status'], 'active')
+        assert_equal(nu6['status'], UpgradeStatus.ACTIVE)
 
         nu6_1 = upgrades[nustr(NU6_1_BRANCH_ID)]
         assert_equal(nu6_1['name'], 'NU6.1')
         assert_equal(nu6_1['activationheight'], 11)
-        assert_equal(nu6_1['status'], 'active')
+        assert_equal(nu6_1['status'], UpgradeStatus.ACTIVE)
 
         # Block subsidy remains the same after NU6
         assert_equal(node.getblocksubsidy()["totalblocksubsidy"], Decimal("6.25"))
@@ -280,47 +281,47 @@ class NuparamsTest(BitcoinTestFramework):
         overwinter = upgrades[nustr(OVERWINTER_BRANCH_ID)]
         assert_equal(overwinter['name'], 'Overwinter')
         assert_equal(overwinter['activationheight'], 1)
-        assert_equal(overwinter['status'], 'active')
+        assert_equal(overwinter['status'], UpgradeStatus.ACTIVE)
 
         sapling = upgrades[nustr(SAPLING_BRANCH_ID)]
         assert_equal(sapling['name'], 'Sapling')
         assert_equal(sapling['activationheight'], 1)
-        assert_equal(sapling['status'], 'active')
+        assert_equal(sapling['status'], UpgradeStatus.ACTIVE)
 
         blossom = upgrades[nustr(BLOSSOM_BRANCH_ID)]
         assert_equal(blossom['name'], 'Blossom')
         assert_equal(blossom['activationheight'], 1)
-        assert_equal(blossom['status'], 'active')
+        assert_equal(blossom['status'], UpgradeStatus.ACTIVE)
 
         heartwood = upgrades[nustr(HEARTWOOD_BRANCH_ID)]
         assert_equal(heartwood['name'], 'Heartwood')
         assert_equal(heartwood['activationheight'], 1)
-        assert_equal(heartwood['status'], 'active')
+        assert_equal(heartwood['status'], UpgradeStatus.ACTIVE)
 
         canopy = upgrades[nustr(CANOPY_BRANCH_ID)]
         assert_equal(canopy['name'], 'Canopy')
         assert_equal(canopy['activationheight'], 1)
-        assert_equal(canopy['status'], 'active')
+        assert_equal(canopy['status'], UpgradeStatus.ACTIVE)
 
         nu5 = upgrades[nustr(NU5_BRANCH_ID)]
         assert_equal(nu5['name'], 'NU5')
         assert_equal(nu5['activationheight'], 7)
-        assert_equal(nu5['status'], 'active')
+        assert_equal(nu5['status'], UpgradeStatus.ACTIVE)
 
         nu6 = upgrades[nustr(NU6_BRANCH_ID)]
         assert_equal(nu6['name'], 'NU6')
         assert_equal(nu6['activationheight'], 9)
-        assert_equal(nu6['status'], 'active')
+        assert_equal(nu6['status'], UpgradeStatus.ACTIVE)
 
         nu6_1 = upgrades[nustr(NU6_1_BRANCH_ID)]
         assert_equal(nu6_1['name'], 'NU6.1')
         assert_equal(nu6_1['activationheight'], 11)
-        assert_equal(nu6_1['status'], 'active')
+        assert_equal(nu6_1['status'], UpgradeStatus.ACTIVE)
 
         nu6_2 = upgrades[nustr(NU6_2_BRANCH_ID)]
         assert_equal(nu6_2['name'], 'NU6.2')
         assert_equal(nu6_2['activationheight'], 13)
-        assert_equal(nu6_2['status'], 'active')
+        assert_equal(nu6_2['status'], UpgradeStatus.ACTIVE)
 
         # Block subsidy remains the same after NU6_1
         assert_equal(node.getblocksubsidy()["totalblocksubsidy"], Decimal("6.25"))

--- a/qa/rpc-tests/test_framework/util.py
+++ b/qa/rpc-tests/test_framework/util.py
@@ -970,8 +970,21 @@ def fail(message=""):
     raise AssertionError(message)
 
 
+class OperationStatus(str, Enum):
+    """The lifecycle status of an async wallet operation, as reported in the
+    `status` field of z_getoperationstatus / z_getoperationresult (and accepted
+    by the `wait_and_assert_operationid_status*` helpers below). Being
+    `str`-valued, a member compares equal to the wire string and can be passed
+    straight to those helpers or compared against RPC output."""
+    QUEUED = 'queued'
+    EXECUTING = 'executing'
+    SUCCESS = 'success'
+    FAILED = 'failed'
+    CANCELLED = 'cancelled'
+
+
 # Returns an async operation result
-def wait_and_assert_operationid_status_result(node, myopid, in_status='success', in_errormsg=None, timeout=300):
+def wait_and_assert_operationid_status_result(node, myopid, in_status=OperationStatus.SUCCESS, in_errormsg=None, timeout=300):
     print('waiting for async operation {}'.format(myopid))
     result = None
     for _ in range(1, timeout):
@@ -989,7 +1002,7 @@ def wait_and_assert_operationid_status_result(node, myopid, in_status='success',
         print('...returned status: {}'.format(status))
 
     errormsg = None
-    if status == "failed":
+    if status == OperationStatus.FAILED:
         errormsg = result['error']['message']
         if debug:
             print('...returned error: {}'.format(errormsg))
@@ -1001,9 +1014,9 @@ def wait_and_assert_operationid_status_result(node, myopid, in_status='success',
 
 
 # Returns txid if operation was a success or None
-def wait_and_assert_operationid_status(node, myopid, in_status='success', in_errormsg=None, timeout=300):
+def wait_and_assert_operationid_status(node, myopid, in_status=OperationStatus.SUCCESS, in_errormsg=None, timeout=300):
     result = wait_and_assert_operationid_status_result(node, myopid, in_status, in_errormsg, timeout)
-    if result['status'] == "success":
+    if result['status'] == OperationStatus.SUCCESS:
         return result['result']['txid']
     else:
         return None
@@ -1450,6 +1463,16 @@ class PrivacyPolicy(str, Enum):
     ALLOW_FULLY_TRANSPARENT = 'AllowFullyTransparent'
     ALLOW_LINKING_ACCOUNT_ADDRESSES = 'AllowLinkingAccountAddresses'
     NO_PRIVACY = 'NoPrivacy'
+
+
+class UpgradeStatus(str, Enum):
+    """The activation status of a network upgrade, as reported in the `status`
+    field of each entry of `getblockchaininfo()['upgrades']`. Being `str`-valued,
+    a member compares equal to the wire string, so it can be asserted directly
+    against RPC output."""
+    DISABLED = 'disabled'
+    PENDING = 'pending'
+    ACTIVE = 'active'
 
 
 def transparent_utxos(wallet: RpcProxy, minconf: int = 1) -> list[dict]:


### PR DESCRIPTION
## Motivation

`util.py` already defines `str`-valued enums (`Pool`, `FundSource`,
`PrivacyPolicy`) to replace magic strings in the RPC tests. This extends that
pattern to the two status fields still written as bare literals across the
**active** suite.

## What changed

- **`OperationStatus`** (`queued`/`executing`/`success`/`failed`/`cancelled`)
  for the async-operation status handled by
  `wait_and_assert_operationid_status[_result]`. The helpers now default to and
  compare against it. It is defined immediately above those helpers (rather than
  with the other enums lower in the file) so the default argument can reference
  it at definition time.
- **`UpgradeStatus`** (`disabled`/`pending`/`active`) for the per-upgrade
  `status` in `getblockchaininfo()['upgrades']`, adopted at the ~73 assertion
  sites in `feature_nu6.py` and `nuparams.py`.

## Safety

Both enums subclass `str`, so a member compares equal to and serializes as its
wire string. The change is behaviour-preserving (`OperationStatus.SUCCESS ==
'success'`, and `assert_equal(UpgradeStatus.PENDING, 'pending')` passes).

## Scope

Only active tests are touched. The other survey candidates (`ReceiverType`,
`AddressType`, `BalanceComponent`) and adoption of the already-defined but
unused `PrivacyPolicy` are left as follow-ups; the bulk of those raw-string
sites live in `DISABLED_SCRIPTS`, so they are lower value and not runnable here.

## Testing

`feature_nu6.py`, `nuparams.py`, and `wallet_ironwood.py` (which exercises the
operation-status helper) pass locally on the zaino backend.