### PR TITLE
ci: cancel superseded interop runs via a concurrency group

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,19 @@ on:
 permissions:
   contents: read
 
+# Cancel a superseded run when a newer one arrives for the same source.
+#
+# Interop requests are grouped by their dispatch action plus a stable per-source
+# key: `source_ref` (the requesting PR number or branch). A rapid follow-up push
+# to the same source PR therefore cancels the prior interop run. A requesting
+# repository that does not yet send `source_ref` falls back to the (per-push
+# unique) head sha and retains its previous no-cancel behavior. Non-dispatch
+# runs group by ref; this repository's own `push` events (i.e. to `main`) are
+# never cancelled, so every landed commit here is fully tested.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'repository_dispatch' && format('{0}-{1}', github.event.action, github.event.client_payload.source_ref || github.event.client_payload.sha) || github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'push' }}
+
 jobs:
   setup:
     name: Define CI matrix

--- a/doc/book/src/ci/cross-repo.md
+++ b/doc/book/src/ci/cross-repo.md
@@ -83,6 +83,12 @@ It may also include these optional fields:
   itself. When provided, the test suite is checked out at this ref instead of
   `main`. This is useful for testing integration-tests changes alongside project
   changes.
+- **`source_ref`**: A stable identifier for the source of the request (e.g.
+  `pr-42` for a pull request, or a branch name such as `main`). It is used only
+  as the [concurrency](https://docs.github.com/actions/using-jobs/using-concurrency)
+  group key, so that a rapid follow-up push for the same source PR cancels the
+  superseded interop run. When omitted, the run groups by `sha` instead, which
+  is unique per push and so never cancels a prior run.
 
 [platform-support]: https://zcash.github.io/integration-tests/user/platform-support.html
 


### PR DESCRIPTION
Adds a workflow-level `concurrency` group to the interop CI so a rapid
follow-up push for the same source PR cancels the prior, now-superseded
integration run — avoiding the wasted compute of letting an obsolete run go to
completion.

Runs are grouped by dispatch action plus the requesting source's `source_ref`
(PR number or branch). Requesters that do not yet send `source_ref` fall back
to the per-push-unique head `sha`, so their behavior is unchanged. This
repository's own `main` pushes are never cancelled, so every landed commit is
fully tested.

Also documents the new optional `source_ref` `client_payload` field in the
cross-repo CI docs.

### Paired changes

The requesting repositories send the new `source_ref`:

- **zcash/zallet#660** — pins this branch as its `ZIT-Revision`, so that PR's
  integration run exercises this concurrency change end to end.
- **ZcashFoundation/zebra** / **zingolabs/zaino** — `source_ref` added on
  branches, to be opened as PRs upstream separately. Until those land they hit
  the `sha` fallback (no behavior change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
