### PR TITLE
test framework: back the cache-rebuild P2P sync with direct block copy

### DIFF
--- a/qa/CHANGELOG.md
+++ b/qa/CHANGELOG.md
@@ -21,6 +21,10 @@ We do not publish package releases or Git tags for this project. Each version en
 
 - Support Zallet's launcher-plus-backend structure: `zallet` is a launcher that execs a per-backend binary. CI builds the launcher plus the `zallet-zaino` backend binary and ships both to the test runners, and the default `zallet.toml` selects the Zaino backend via its top-level `backend` key. The build falls back to the single-binary layout when the checked-out wallet has no `backends/` directory.
 
+### Fixed
+
+- `rebuild_cache` no longer fails when the 8-node zebrad mesh does not converge over P2P within `sync_blocks_with_reconnect`'s retries (zebra #10329, #10332): the straggler recovery that already backstopped the post-restart reconnect — copying the missing blocks directly via `getblock`/`submitblock` — is hoisted into a shared `copy_missing_blocks` helper and now also backstops the per-round sync in the mining loop. Cache creation therefore no longer depends on P2P block relay for correctness, only for speed.
+
 ## [0.1.0] - 2025-11-11
 
 In this first (pseudo)-release, we document all the changes made while migrating from the original Zcash test framework (`zcashd` only) to the new Z3 stack (`zebrad` + `zallet`), now hosted within the Zebra repository as part of the zebra-rpc crate.

--- a/qa/rpc-tests/test_framework/util.py
+++ b/qa/rpc-tests/test_framework/util.py
@@ -242,6 +242,33 @@ def sync_blocks_with_reconnect(rpcs, peer_idx, max_attempts=3, reconnect_pause=2
                 time.sleep(reconnect_pause)
     raise last_err
 
+def copy_missing_blocks(rpcs, tip_idx):
+    """Bring every node up to `rpcs[tip_idx]`'s tip by copying the missing
+    blocks directly via getblock/submitblock.
+
+    Deterministic alternative to waiting on P2P relay, which can leave a
+    peer stuck behind indefinitely (zebra #10329, #10332). Only valid while
+    all nodes are on one non-forked chain, as in `rebuild_cache`.
+    """
+    target_height = rpcs[tip_idx].getblockcount()
+    stragglers = {i: rpcs[i].getblockcount() for i in range(len(rpcs))
+                  if rpcs[i].getblockcount() < target_height}
+    if not stragglers:
+        return
+    print(
+        "[copy_missing_blocks] {} node(s) behind height {}: {}; "
+        "copying the missing blocks directly".format(
+            len(stragglers), target_height, stragglers),
+        file=sys.stderr, flush=True,
+    )
+    for i, height in stragglers.items():
+        for h in range(height + 1, target_height + 1):
+            rpcs[i].submitblock(rpcs[tip_idx].getblock(str(h), 0))
+        assert_equal(
+            rpcs[i].getblockcount(), target_height,
+            "node {} still behind after copying blocks {}..{} from "
+            "node {}".format(i, height + 1, target_height, tip_idx))
+
 def sync_mempools(nodes, wallets=None, wait=0.5, timeout=60):
     """
     Wait until everybody has the same transactions in their memory
@@ -475,7 +502,14 @@ def initialize_chain(test_dir, num_nodes, cachedir, cache_behavior='current'):
                     block_time += PRE_BLOSSOM_BLOCK_TARGET_SPACING
                 # Must sync before next peer mines; retry variant handles the
                 # 8-node mesh occasionally missing sync_blocks's 60s window.
-                sync_blocks_with_reconnect(rpcs, peer)
+                # If P2P still hasn't converged after the retries, copy the
+                # blocks over RPC instead of failing: the mining peer is by
+                # construction the unique tip, so a straggler just needs its
+                # blocks replayed.
+                try:
+                    sync_blocks_with_reconnect(rpcs, peer)
+                except AssertionError:
+                    copy_missing_blocks(rpcs, peer)
                 # Shut down and restart every zebrad node.
                 # This works around a zebrad problem where it won't broadcast
                 # received blocks to other connected nodes, and is a workaround
@@ -536,22 +570,7 @@ def initialize_chain(test_dir, num_nodes, cachedir, cache_behavior='current'):
             if all(r.getblockcount() == target_height for r in rpcs):
                 break
             time.sleep(1)
-        straggler_heights = {i: rpcs[i].getblockcount() for i in range(MAX_NODES)
-                             if rpcs[i].getblockcount() < target_height}
-        if straggler_heights:
-            print(
-                "[rebuild_cache] P2P left {} node(s) behind height {}: {}; "
-                "copying the missing blocks directly".format(
-                    len(straggler_heights), target_height, straggler_heights),
-                file=sys.stderr, flush=True,
-            )
-            for i, height in straggler_heights.items():
-                for h in range(height + 1, target_height + 1):
-                    rpcs[i].submitblock(rpcs[tip_node].getblock(str(h), 0))
-                assert_equal(
-                    rpcs[i].getblockcount(), target_height,
-                    "node {} still behind after copying blocks {}..{} from "
-                    "node {}".format(i, height + 1, target_height, tip_node))
+        copy_missing_blocks(rpcs, tip_node)
         # Check that local time isn't going backwards
         assert_greater_than(time.time() + 1, block_time)
 


### PR DESCRIPTION
The per-round sync in rebuild_cache's mining loop relied entirely on zebrad's regtest P2P relay converging within sync_blocks_with_reconnect's retries, and failed the whole test run when it didn't. The deterministic recovery used after the final restart -- copying the missing blocks to stragglers via getblock/submitblock -- applies equally there: the mining peer is by construction the unique tip of one non-forked chain. Hoist that recovery into a shared copy_missing_blocks helper and fall back to it when the per-round sync times out.