### PR TITLE
test: Use a Sapling+Orchard source for the combined-input Ironwood case

### DIFF
--- a/qa/rpc-tests/wallet_ironwood_crosspool.py
+++ b/qa/rpc-tests/wallet_ironwood_crosspool.py
@@ -7,15 +7,19 @@
 # Ironwood (NU6.3, ZIP 2005) cross-pool spends, against the Z3 stack
 # (zebrad + zaino + zallet).
 #
-# A z_sendmany `fromaddress` resolves to an account, and the default spend
-# policy permits drawing from every shielded pool the account holds. This test
-# exercises Ironwood interacting with Sapling across the turnstile:
+# A z_sendmany `fromaddress` resolves to an account, and the spend policy
+# derives from the value pools the address's receivers name (zcash/zallet#756):
+# a Sapling receiver permits the Sapling pool, and an Orchard receiver permits
+# the Orchard and Ironwood pools (payments to Orchard receivers land in the
+# Ironwood bundle once NU6.3 is active). This test exercises Ironwood
+# interacting with Sapling across the turnstile:
 #   1. Turnstile crossing Ironwood -> Sapling: with only Ironwood funds, paying
-#      a Sapling receiver moves value across pools; the recipient note is
-#      Sapling and becomes spendable there.
+#      a Sapling receiver from an Orchard-only address moves value across
+#      pools; the recipient note is Sapling and becomes spendable there.
 #   2. Sapling + Ironwood combined inputs: a payment larger than either pool's
-#      total forces the wallet to draw from both a Sapling note and an Ironwood
-#      note in one transaction.
+#      total, sent from an address whose receivers name both pools, forces the
+#      wallet to draw from both a Sapling note and an Ironwood note in one
+#      transaction.
 #
 # Cross-pool sends reveal amounts across the turnstile, so they are issued with
 # the `AllowRevealedAmounts` privacy policy. All sends stay within one account
@@ -122,7 +126,13 @@ class WalletIronwoodCrossPoolTest(IronwoodTestFramework):
                     "combined balance must cover the payment")
         combine_zec = (Decimal(combine_zat) / COIN).quantize(Decimal('0.0001'))
 
-        view = self.cross_pool_send(node, w, orchard_ua, orchard_ua, combine_zec)
+        # The source must carry both Sapling and Orchard receivers: the spend
+        # policy permits only the pools the fromaddress's receivers name, so an
+        # Orchard-only source could draw on Ironwood but never on the Sapling
+        # note this test needs combined (zcash/zallet#756).
+        combined_ua = w.z_getaddressforaccount(
+            acct, ['sapling', 'orchard'])['address']
+        view = self.cross_pool_send(node, w, combined_ua, orchard_ua, combine_zec)
         assert_true(len(spends_in_pool(view, Pool.SAPLING)) >= 1,
                     "combined payment should spend a Sapling note; got {}"
                     .format(view['spends']))


### PR DESCRIPTION
Closes #192.

## Motivation

zcash/zallet#756 changes `z_sendmany` to derive the spend policy from the value pools the `fromaddress`'s receivers name, instead of permitting every shielded pool the account holds. Test 2 of `qa/rpc-tests/wallet_ironwood_crosspool.py` sends from an **Orchard-only** unified address while expecting the wallet to combine a Sapling note with an Ironwood note — under the new policy an Orchard receiver names only the Orchard and Ironwood pools, so the Sapling note can no longer be selected and the send fails as insufficient funds.

Flagged in review of zcash/zallet#756 by @schell: the combined-input case needs a source whose receivers actually name both pools.

## Solution

- Test 2 now sends from a unified address carrying **both Sapling and Orchard receivers** (`z_getaddressforaccount(acct, ['sapling', 'orchard'])`), so the policy permits {Sapling, Orchard, Ironwood} and the test exercises exactly what it intends: neither pool alone covers the payment, both must contribute an input.
- The file header comment describing the old every-pool default policy now describes the receiver-derived policy.
- Test 1 is unchanged: an Orchard-only source spending Ironwood funds is still permitted, and the Sapling-output crossing was already issued with `AllowRevealedAmounts`.

Pairs with zcash/zallet#756, which will carry `ZIT-Revision: fix/ironwood-crosspool-receiver-pools` so its CI exercises this branch until both merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)